### PR TITLE
Temp revert server side tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@duckdb/duckdb-wasm": "^1.30.0",
         "@highlightjs/vue-plugin": "^2.1.0",
         "@primevue/themes": "^4.4.1",
-        "@vueuse/core": "^14.1.0",
         "js-yaml": "^4.1.1",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
@@ -1169,12 +1168,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/web-bluetooth": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-      "license": "MIT"
-    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -1613,44 +1606,6 @@
         "vue": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vueuse/core": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.1.0.tgz",
-      "integrity": "sha512-rgBinKs07hAYyPF834mDTigH7BtPqvZ3Pryuzt1SD/lg5wEcWqvwzXXYGEDb2/cP0Sj5zSvHl3WkmMELr5kfWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "14.1.0",
-        "@vueuse/shared": "14.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.0"
-      }
-    },
-    "node_modules/@vueuse/metadata": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.1.0.tgz",
-      "integrity": "sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.1.0.tgz",
-      "integrity": "sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.0"
       }
     },
     "node_modules/abbrev": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@duckdb/duckdb-wasm": "^1.30.0",
     "@highlightjs/vue-plugin": "^2.1.0",
     "@primevue/themes": "^4.4.1",
-    "@vueuse/core": "^14.1.0",
     "js-yaml": "^4.1.1",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",

--- a/src/components/QuickStartCode.vue
+++ b/src/components/QuickStartCode.vue
@@ -102,12 +102,16 @@ interface Props {
   currentFilters: Record<string, string[]>;
 
   /**
+   * The raw data rows returned by the catalog/search. Each row is expected
+   * to be an object and may contain fields such as `path` and `file_id`.
+   */
+  rawData: any[];
+
+  /**
    * Dynamic filter options for each column (filtered based on other active filters).
    * Used to determine if there are multiple variable_cell_methods options available.
    */
   dynamicFilterOptions: Record<string, string[]>;
-
-  numDatasets: number;
 }
 
 /** The typed props object (available in <script setup> via defineProps). */
@@ -185,7 +189,25 @@ const requiredProjects = computed(() => {
   return Array.from(projects).sort();
 });
 
-const numDatasets = props.numDatasets;
+/**
+ * Number of unique datasets present in `props.rawData`.
+ *
+ * This counts unique `file_id` values using a Set. Useful for deciding
+ * whether the generated xarray snippet should produce a dictionary of
+ * datasets or a single dataset.
+ */
+const numDatasets = computed(() => {
+  // Use a Set to count unique datasets - one fileId per dataset
+  const fileIds = new Set<string>();
+
+  props.rawData.forEach((row) => {
+    if (row['file_id']) {
+      fileIds.add(row['file_id']);
+    }
+  });
+
+  return fileIds.size;
+});
 
 /**
  * Determine whether to show the MultipleCellMethodsWarning.
@@ -200,7 +222,7 @@ const numDatasets = props.numDatasets;
  */
 const shouldShowCellMethodsWarning = computed((): boolean => {
   if (!isXArrayMode.value) return false;
-  if (numDatasets !== 1) return false;
+  if (numDatasets.value !== 1) return false;
 
   // Don't show warning if user has already filtered by variable_cell_methods
   const hasFilteredTemporalLabels = (props.currentFilters['temporal_label']?.length ?? 0) > 0;
@@ -252,8 +274,8 @@ datastore = intake.cat.access_nri["${props.datastoreName}"]`;
 
   // Add XArray conversion if in XArray mode
   if (isXArrayMode.value) {
-    if (numDatasets > 1) {
-      code += `\n\n# Search contains ${numDatasets} datasets. This will generate a dataset dictionary: see https://intake-esm.readthedocs.io/en/stable/`;
+    if (numDatasets.value > 1) {
+      code += `\n\n# Search contains ${numDatasets.value} datasets. This will generate a dataset dictionary: see https://intake-esm.readthedocs.io/en/stable/`;
       code += `\n# To get to a single dataset, you will need to filter down to a single File ID.`;
       code += `\ndataset_dict = datastore.to_dataset_dict()\ndataset_dict`;
     } else {

--- a/src/components/__tests__/DatastoreDetail.spec.ts
+++ b/src/components/__tests__/DatastoreDetail.spec.ts
@@ -272,8 +272,8 @@ describe('DatastoreDetail', () => {
     expect(wrapper.vm.currentFilters).toEqual({});
   });
 
-  // Test that filters are correctly set in the component
-  it('sets filters correctly', async () => {
+  // Test that filtered data correctly applies filter logic to raw data
+  it('filters data based on current filters', async () => {
     await router.isReady();
 
     vi.spyOn(catalogStore, 'getDatastoreFromCache').mockReturnValue(createMockDatastoreCache());
@@ -285,7 +285,9 @@ describe('DatastoreDetail', () => {
     wrapper.vm.currentFilters = { frequency: ['daily'] };
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.vm.currentFilters.frequency).toEqual(['daily']);
+    const filtered = wrapper.vm.filteredData;
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].frequency).toBe('daily');
   });
 
   // Test that column names are formatted with proper capitalization
@@ -365,7 +367,7 @@ describe('DatastoreDetail', () => {
     // Check QuickStartCode props
     const quickStart = wrapper.findComponent({ name: 'QuickStartCode' });
     expect(quickStart.props('datastoreName')).toBe('test-datastore');
-    expect(quickStart.props('numDatasets')).toBeDefined();
+    expect(quickStart.props('rawData')).toEqual(mockDatastoreData);
 
     // Check FilterSelectors props
     const filters = wrapper.findComponent({ name: 'FilterSelectors' });
@@ -378,11 +380,11 @@ describe('DatastoreDetail', () => {
     // Check DatastoreTable props
     const table = wrapper.findComponent({ name: 'DatastoreTable' });
     expect(table.props('datastoreName')).toBe('test-datastore');
-    expect(table.props('columns')).toBeDefined();
+    expect(table.props('filteredData')).toEqual(mockDatastoreData);
   });
 
-  // Test that filters handle array values correctly
-  it('filters array values correctly', async () => {
+  // Test that filters handle array values in data correctly
+  it('filters array values in data correctly', async () => {
     await router.isReady();
 
     vi.spyOn(catalogStore, 'getDatastoreFromCache').mockReturnValue(createMockDatastoreCache());
@@ -394,11 +396,13 @@ describe('DatastoreDetail', () => {
     wrapper.vm.currentFilters = { variable: ['temp'] };
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.vm.currentFilters.variable).toEqual(['temp']);
+    const filtered = wrapper.vm.filteredData;
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].variable).toContain('temp');
   });
 
-  // Test that empty filters are correctly set
-  it('handles empty filters correctly', async () => {
+  // Test that empty filters show all data
+  it('shows all data when no filters are applied', async () => {
     await router.isReady();
 
     vi.spyOn(catalogStore, 'getDatastoreFromCache').mockReturnValue(createMockDatastoreCache());
@@ -409,7 +413,7 @@ describe('DatastoreDetail', () => {
     wrapper.vm.currentFilters = {};
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.vm.currentFilters).toEqual({});
+    expect(wrapper.vm.filteredData).toEqual(mockDatastoreData);
   });
 
   // Test that selected columns can be updated

--- a/src/components/__tests__/QuickStartCode.spec.ts
+++ b/src/components/__tests__/QuickStartCode.spec.ts
@@ -46,7 +46,6 @@ describe('QuickStartCode', () => {
     return mount(QuickStartCode, {
       props: {
         dynamicFilterOptions: {},
-        numDatasets: 1, // Default to 1 dataset
         ...props,
       },
       global: {
@@ -69,7 +68,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain('Quick Start');
@@ -80,7 +79,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'my-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain('intake.cat.access_nri["my-datastore"]');
@@ -93,7 +92,7 @@ describe('QuickStartCode', () => {
       currentFilters: {
         project: ['xp65'],
       },
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain("datastore.search(project='xp65')");
@@ -106,7 +105,7 @@ describe('QuickStartCode', () => {
       currentFilters: {
         variable: ['tas', 'pr', 'huss'],
       },
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain('datastore.search(variable=["tas","pr","huss"])');
@@ -121,7 +120,7 @@ describe('QuickStartCode', () => {
         variable: ['tas'],
         frequency: ['1mon'],
       },
-      numDatasets: 0,
+      rawData: [],
     });
 
     const text = wrapper.text();
@@ -137,7 +136,7 @@ describe('QuickStartCode', () => {
       currentFilters: {
         project: ['xp65'],
       },
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain('with current filters');
@@ -148,7 +147,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).not.toContain('with current filters');
@@ -159,7 +158,10 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [
+        { file_id: 'dataset1', path: '/g/data/xp65/file1.nc' },
+        { file_id: 'dataset1', path: '/g/data/xp65/file2.nc' },
+      ],
     });
 
     // Component starts in xarray mode by default
@@ -171,7 +173,11 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 3,
+      rawData: [
+        { file_id: 'dataset1', path: '/g/data/xp65/file1.nc' },
+        { file_id: 'dataset2', path: '/g/data/xp65/file2.nc' },
+        { file_id: 'dataset3', path: '/g/data/xp65/file3.nc' },
+      ],
     });
 
     const text = wrapper.text();
@@ -184,7 +190,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
     });
 
     // Find and toggle the switch to ESM mode (off)
@@ -201,7 +207,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -216,7 +222,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -233,7 +239,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -255,7 +261,7 @@ describe('QuickStartCode', () => {
         project: ['xp65'],
         variable: ['tas', 'pr'],
       },
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -271,7 +277,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -286,7 +292,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const warningComponent = wrapper.findComponent({ name: 'RequiredProjectsWarning' });
@@ -312,7 +318,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     const warningComponent = wrapper.findComponent({ name: 'RequiredProjectsWarning' });
@@ -334,7 +340,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: longFilters,
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -359,7 +365,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: longFilters,
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -386,7 +392,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: longFilters,
-      numDatasets: 0,
+      rawData: [],
     });
 
     const buttons = wrapper.findAllComponents({ name: 'Button' });
@@ -406,7 +412,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
     });
 
     // Should start in xarray mode
@@ -424,12 +430,12 @@ describe('QuickStartCode', () => {
     expect(wrapper.text()).toContain('to_dask()');
   });
 
-  // Test that zero datasets doesn't break the component
+  // Test that empty rawData doesn't break the component
   it('handles empty rawData gracefully', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 0,
+      rawData: [],
     });
 
     expect(wrapper.text()).toContain('Quick Start');
@@ -437,12 +443,12 @@ describe('QuickStartCode', () => {
     expect(wrapper.text()).toContain('intake.cat.access_nri["test-datastore"]');
   });
 
-  // Test that datasets are handled correctly
+  // Test that rawData without file_id is handled correctly
   it('handles rawData without file_id', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 2,
+      rawData: [{ path: '/g/data/xp65/file1.nc' }, { path: '/g/data/xp65/file2.nc' }],
     });
 
     // Should still render without errors
@@ -454,7 +460,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
       dynamicFilterOptions: {
         variable_cell_methods: ['time: mean', 'time: point', 'area: mean'],
         temporal_label: ['mean', 'point', 'mean'],
@@ -469,7 +475,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
       dynamicFilterOptions: {
         variable_cell_methods: ['time: mean'],
       },
@@ -483,7 +489,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 2,
+      rawData: [{ file_id: 'dataset1' }, { file_id: 'dataset2' }],
       dynamicFilterOptions: {
         variable_cell_methods: ['time: mean', 'time: point'],
       },
@@ -497,7 +503,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
       dynamicFilterOptions: {
         variable_cell_methods: ['time: mean', 'time: point'],
       },
@@ -515,7 +521,7 @@ describe('QuickStartCode', () => {
     wrapper = createWrapper({
       datastoreName: 'test-datastore',
       currentFilters: {},
-      numDatasets: 1,
+      rawData: [{ file_id: 'dataset1' }],
       dynamicFilterOptions: {},
     });
 

--- a/src/stores/catalogStore.ts
+++ b/src/stores/catalogStore.ts
@@ -1,8 +1,8 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import duckdb_wasm from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url';
-import mvp_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url';
+import duckdb_wasm from '@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url';
+import mvp_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url';
 
 type OptionalProject = string | null;
 /**
@@ -58,22 +58,16 @@ export interface DatastoreCache {
   project?: OptionalProject;
 }
 
-interface RowCountResponse {
-  num_rows: number;
-}
-
-interface DatastoreRow {
-  [key: string]: string | string[] | null;
-}
-
 type FilterOptions = Record<string, string[]>;
 
-const trackingServicesBaseUrl =
-  process.env.NODE_ENV === 'production'
-    ? 'https://reporting-dev.access-nri-store.cloud.edu.au/'
-    : 'http://127.0.0.1:8000/';
+/**
+ * URL to the metacatalog parquet file. Uses a CORS proxy in production
+ * and a local API path in development.
+ */
 const METACAT_URL =
-  'https://object-store.rc.nectar.org.au/v1/AUTH_685340a8089a4923a71222ce93d5d323/access-nri-intake-catalog/metacatalog.parquet';
+  process.env.NODE_ENV === 'production'
+    ? 'https://object-store.rc.nectar.org.au/v1/AUTH_685340a8089a4923a71222ce93d5d323/access-nri-intake-catalog/metacatalog.parquet'
+    : '/api/parquet/metacatalog.parquet';
 
 /** DuckDB WASM bundles used by the client; selectBundle picks the best one. */
 const DUCKDB_BUNDLES: duckdb.DuckDBBundles = {
@@ -225,20 +219,74 @@ export const useCatalogStore = defineStore('catalog', () => {
   }
 
   /**
-   * Read an esm datastore from the `datastore-content` endpoint, and get a JS
-   * array containing the data
+   * Read a generic ESM datastore parquet and normalize each column to
+   * either a scalar or an array of strings. This function dynamically
+   * inspects the parquet schema and builds a query that coercively
+   * converts columns into VARCHAR[] when possible.
    *
-   * @param datastoreName - The name of the datastore, passed to the tracking
-   * services server as part of the url, eg. `.../intake/table/datastore-content/WOA23`
+   * @param db - DuckDB Async instance
+   * @param conn - Active connection associated with `db`
+   * @param uint8Array - Bytes of the datastore parquet
+   * @param datastoreName - Logical name used to register the buffer
    */
-  async function queryEsmDatastore(datastoreName: string): Promise<DatastoreRow[]> {
-    const endpoint = `${trackingServicesBaseUrl}intake/table/datastore-content/${datastoreName}`;
+  async function queryEsmDatastore(conn: duckdb.AsyncDuckDBConnection, fileName: string): Promise<any[]> {
+    // NOTE: the parquet file buffer must be registered by the caller.
+    // First, inspect the schema to understand the columns
+    const schemaResult = await conn.query(`DESCRIBE SELECT * FROM read_parquet('${fileName}') LIMIT 1`);
 
-    const transformedData = await fetch(endpoint).then((response) => {
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
-      }
-      return response.json();
+    const schemaData = schemaResult.toArray();
+    console.log('📊 ESM Datastore schema:', schemaData);
+    // Get all column names from the schema
+    const columns = schemaData
+      .map((row: any) => row.column_name)
+      .filter((col: string) => col !== 'filename' && col !== 'path');
+    console.log('📋 Available columns:', columns);
+
+    // Read the parquet as raw rows and normalize in JavaScript
+    const queryResult = await conn.query(`SELECT * FROM read_parquet('${fileName}')`);
+    const rawData = queryResult.toArray();
+
+    // Transform the data using the same normalization used by
+    // `queryMetaCatalogPq`: always produce an array of strings for
+    // each column (empty array for null/undefined).
+    const transformedData = rawData.map((row: any) => {
+      const processGenericField = (value: any): string[] => {
+        if (value === null || value === undefined) return [];
+
+        // DuckDB Vector-like objects (expose toArray)
+        if (value && typeof value.toArray === 'function') {
+          return value
+            .toArray()
+            .filter((v: any) => v !== null && v !== undefined)
+            .map(String);
+        }
+
+        // Regular arrays
+        if (Array.isArray(value)) {
+          return value.filter((v) => v !== null && v !== undefined).map(String);
+        }
+
+        // Strings may be JSON arrays or scalars
+        if (typeof value === 'string') {
+          try {
+            const parsed = JSON.parse(value);
+            return Array.isArray(parsed) ? parsed.map(String) : [String(parsed)];
+          } catch {
+            return [value];
+          }
+        }
+
+        // Fallback: stringify single value
+        return [String(value)];
+      };
+
+      const transformedRow: any = {};
+      columns.forEach((column) => {
+        const arr = processGenericField(row[column]);
+        transformedRow[column] = arr.length === 0 ? null : arr.length === 1 ? arr[0] : arr;
+      });
+
+      return transformedRow;
     });
 
     console.log('✅ ESM Datastore transformed data sample:', transformedData.slice(0, 2));
@@ -256,16 +304,23 @@ export const useCatalogStore = defineStore('catalog', () => {
    * @param uint8Array - Bytes of the datastore parquet
    * @param datastoreName - Logical name used to register the buffer
    */
-  async function getEsmDatastoreProject(datastoreName: string): Promise<OptionalProject> {
-    const endpoint = `${trackingServicesBaseUrl}intake/table/datastore-project/${datastoreName}`;
-    return fetch(endpoint)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
-        }
-        return response.json();
-      })
-      .then((response) => response.project);
+  async function getEsmDatastoreProject(
+    conn: duckdb.AsyncDuckDBConnection,
+    fileName: string,
+  ): Promise<OptionalProject> {
+    // NOTE: the parquet file buffer must be registered by the caller.
+    // Query for a single row and return the first matched project (or null)
+    return conn
+      .query(`SELECT path FROM read_parquet('${fileName}') LIMIT 1`)
+      .then((table) => table.toArray())
+      .then((rows: any[]) => {
+        const row = rows[0];
+        if (!row) return null;
+        const pathValue = row['path'];
+        if (!pathValue) return null;
+        const match = String(pathValue).match(/\/g\/data\/([^\/]+)\//);
+        return match?.[1] ?? null;
+      });
   }
 
   // Actions
@@ -309,23 +364,6 @@ export const useCatalogStore = defineStore('catalog', () => {
       if (db) await db.terminate();
       loading.value = false;
     }
-  }
-
-  async function getEsmDatastoreSize(datastoreName: string): Promise<number> {
-    const endpoint = `${trackingServicesBaseUrl}intake/table/row-count/${datastoreName}`;
-
-    return fetch(endpoint)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data: RowCountResponse) => data.num_rows)
-      .catch((error) => {
-        console.error('Error fetching row count:', error);
-        return 0;
-      });
   }
 
   /** Reset catalog-related state held by the store. */
@@ -394,18 +432,17 @@ export const useCatalogStore = defineStore('catalog', () => {
 
   // Datastore management functions
   /**
-   * Load or return cached ESM datastore metadata. This only fetches column names,
-   * filter options, and row count - not the actual data rows. The DatastoreTable
-   * component handles fetching actual data with server-side pagination via the
-   * esm-datastore endpoint.
+   * Load or return a cached ESM datastore. If the datastore is not cached
+   * the function will fetch the parquet file, parse it via DuckDB and
+   * populate the cache entry for later reuse.
    *
    * @param datastoreName - logical name used to locate the parquet file
    */
   async function loadDatastore(datastoreName: string): Promise<DatastoreCache> {
     // Check if already cached and not loading
     const cached = datastoreCache.value[datastoreName];
-    if (cached && cached.columns.length > 0 && !cached.loading) {
-      console.log(`✅ Using cached metadata for ${datastoreName}`);
+    if (cached && cached.data.length > 0 && !cached.loading) {
+      console.log(`✅ Using cached data for ${datastoreName}`);
       return cached;
     }
 
@@ -435,49 +472,66 @@ export const useCatalogStore = defineStore('catalog', () => {
     let conn: duckdb.AsyncDuckDBConnection | null = null;
 
     try {
-      console.log(`🚀 Loading datastore metadata: ${datastoreName}`);
+      console.log(`🚀 Loading datastore: ${datastoreName}`);
 
-      // Construct URL for the sidecar file containing unique values
-      const datastoreUrl = `https://object-store.rc.nectar.org.au/v1/AUTH_685340a8089a4923a71222ce93d5d323/access-nri-intake-catalog/source/${datastoreName}.parquet`;
+      // Construct URLs for both the main datastore and sidecar files
+      const datastoreUrl =
+        process.env.NODE_ENV === 'production'
+          ? `https://object-store.rc.nectar.org.au/v1/AUTH_685340a8089a4923a71222ce93d5d323/access-nri-intake-catalog/source/${datastoreName}.parquet`
+          : `/api/parquet/source/${datastoreName}.parquet`;
+
       const sidecarUrl = datastoreUrl.replace('.parquet', '_uniqs.parquet');
 
-      // Fetch sidecar file and initialize DuckDB concurrently
-      const [sidecarArrayBuffer, dbConnection] = await Promise.all([
-        fetch(sidecarUrl, { method: 'GET' }).then((response) => {
-          if (!response.ok) {
-            throw new Error(`Failed to fetch sidecar parquet file: ${response.status}`);
-          }
-          return response.arrayBuffer();
-        }),
+      // Fetch both parquet files and initialize DuckDB concurrently
+      const [response, sidecarResponse, dbConnection] = await Promise.all([
+        fetch(datastoreUrl),
+        fetch(sidecarUrl),
         initializeDuckDB(),
       ]);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch datastore parquet file: ${response.status}`);
+      }
+
+      if (!sidecarResponse.ok) {
+        throw new Error(`Failed to fetch sidecar parquet file: ${sidecarResponse.status}`);
+      }
+
+      const [arrayBuffer, sidecarArrayBuffer] = await Promise.all([
+        response.arrayBuffer(),
+        sidecarResponse.arrayBuffer(),
+      ]);
+
+      const uint8Array = new Uint8Array(arrayBuffer);
+      const sidecarUint8Array = new Uint8Array(sidecarArrayBuffer);
+      console.log(`📦 Downloaded ${uint8Array.length} bytes for ${datastoreName}`);
+      console.log(`📦 Downloaded ${sidecarUint8Array.length} bytes for sidecar file`);
 
       db = dbConnection.db;
       conn = dbConnection.conn;
 
-      // Register the sidecar file with DuckDB
-      const sidecarUint8Array = new Uint8Array(sidecarArrayBuffer);
+      // Register both parquet files
+      const fileName = `${datastoreName}.parquet`;
       const sidecarFileName = `${datastoreName}_uniqs.parquet`;
-      console.log(`📦 Downloaded ${sidecarUint8Array.length} bytes for sidecar file`);
-
+      await db.registerFileBuffer(fileName, uint8Array);
       await db.registerFileBuffer(sidecarFileName, sidecarUint8Array);
 
-      // Query metadata: project, filter options, and row count
-      // Note: We fetch a small sample just to get column names
-      const [sampleData, project, filterOptions, numRecords] = await Promise.all([
-        queryEsmDatastore(datastoreName), // Gets first 100 rows just for column names
-        getEsmDatastoreProject(datastoreName),
+      // Query the ESM datastore data, project, and filter options concurrently
+      const [datastoreData, project, filterOptions] = await Promise.all([
+        queryEsmDatastore(conn, fileName),
+        getEsmDatastoreProject(conn, fileName),
         getFilterOptions(conn, sidecarFileName),
-        getEsmDatastoreSize(datastoreName),
       ]);
 
-      const columns = Object.keys(sampleData[0] || {});
+      const columns = Object.keys(datastoreData[0] || {});
       const displayColumns = setupColumns(columns);
 
-      // Update cache with metadata only (no data rows stored)
+      // Also extract project from the datastore (first row path)
+
+      // Update cache with loaded data
       datastoreCache.value[datastoreName] = {
-        data: [], // Don't store data - it's fetched on-demand by DatastoreTable
-        totalRecords: numRecords,
+        data: datastoreData,
+        totalRecords: datastoreData.length,
         columns: displayColumns,
         filterOptions,
         loading: false,
@@ -486,12 +540,10 @@ export const useCatalogStore = defineStore('catalog', () => {
         lastFetched: new Date(),
       };
 
-      console.log(
-        `✅ Loaded metadata for ${datastoreName}: ${displayColumns.length} columns, ${numRecords} total records`,
-      );
+      console.log(`✅ Loaded ${datastoreData.length} records for ${datastoreName}`);
       return datastoreCache.value[datastoreName];
     } catch (err) {
-      console.error('❌ Error loading datastore metadata:', err);
+      console.error('❌ Error loading datastore:', err);
       const errorMessage = err instanceof Error ? err.message : 'Failed to load datastore';
 
       datastoreCache.value[datastoreName] = {
@@ -573,6 +625,5 @@ export const useCatalogStore = defineStore('catalog', () => {
     queryEsmDatastore,
     getFilterOptions,
     setupColumns,
-    getEsmDatastoreSize,
   };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,15 @@ export default defineConfig({
     __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
   },
   server: {
+    proxy: {
+      '/api/parquet': {
+        target:
+          'https://object-store.rc.nectar.org.au/v1/AUTH_685340a8089a4923a71222ce93d5d323/access-nri-intake-catalog',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/parquet/, ''),
+        secure: true,
+      },
+    },
     headers: {
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Opener-Policy': 'same-origin',


### PR DESCRIPTION
Looks like we are OOMing and causing a 500 when running on a Nectar Instance. 

This PR reverts to doing everything server side (until I figure out what the issue is - will be after Jo gets back from leave), at the expense of bricking large NCI datastores temporarily.

See https://github.com/ACCESS-NRI/tracking-services/pull/156 (for those with permissions)
