### PR TITLE
Update header CSS to always right align 'Documentation'

### DIFF
--- a/src/components/DatastoreHeader.vue
+++ b/src/components/DatastoreHeader.vue
@@ -12,7 +12,7 @@
 
     <!-- Right side - Documentation links -->
     <div class="flex-shrink-0">
-      <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 lg:text-right">Documentation</div>
+      <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-right">Documentation</div>
       <div class="flex flex-col space-y-2 items-end">
         <a
           href="https://intake-esm.readthedocs.io/"

--- a/src/components/MetacatHeader.vue
+++ b/src/components/MetacatHeader.vue
@@ -36,7 +36,7 @@
 
     <!-- Right side - Documentation links -->
     <div class="flex-shrink-0">
-      <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 lg:text-right">Documentation</div>
+      <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-right">Documentation</div>
       <div class="flex flex-col space-y-2 items-end">
         <a
           href="https://intake-esm.readthedocs.io/"


### PR DESCRIPTION
Looks much better/more consistent.

Change 'lg:text-right' to 'text-right' (tailwind) in headers for documentation