### PR TITLE
Make toast configurable in FilterSelectors

### DIFF
--- a/src/components/FilterSelectors.vue
+++ b/src/components/FilterSelectors.vue
@@ -39,6 +39,7 @@ interface Props {
   filterOptions: Record<string, string[]>;
   modelValue: Record<string, string[]>;
   dynamicFilterOptions: Record<string, string[]>;
+  toast: boolean;
 }
 
 interface Emits {
@@ -135,12 +136,14 @@ const getSortedOptions = (fallbackOptions: string[], searchTerm?: string) => {
 const updateFilter = (column: string, value: string[]) => {
   const updatedFilters = { ...props.modelValue, [column]: value };
   emit('update:modelValue', updatedFilters);
-  toast.add({
-    severity: 'info',
-    summary: 'Filters Updated',
-    detail: 'Quickstart Code updated with current filters',
-    life: 2500,
-  });
+  if (props.toast) {
+    toast.add({
+      severity: 'info',
+      summary: 'Filters Updated',
+      detail: 'Quickstart Code updated with current filters',
+      life: 2500,
+    });
+  }
 };
 
 const handleClear = () => {

--- a/src/components/MetacatTable.vue
+++ b/src/components/MetacatTable.vue
@@ -9,6 +9,7 @@
       :filter-options="filterOptions"
       :dynamic-filter-options="dynamicFilterOptions"
       @clear="clearFilters"
+      :toast="false"
     />
 
     <!-- Loading State -->

--- a/src/components/__tests__/FilterSelectors.spec.ts
+++ b/src/components/__tests__/FilterSelectors.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import FilterSelectors from '../FilterSelectors.vue';
 import MultiSelect from 'primevue/multiselect';
@@ -7,10 +7,15 @@ import PrimeVue from 'primevue/config';
 import ToastService from 'primevue/toastservice';
 import Aura from '@primeuix/themes/aura';
 
+// Hoist the mock add function so it can be referenced in tests
+const { mockToastAdd } = vi.hoisted(() => ({
+  mockToastAdd: vi.fn(),
+}));
+
 // Mock useToast to avoid actual toast service calls in tests
 vi.mock('primevue/usetoast', () => ({
   useToast: () => ({
-    add: vi.fn(),
+    add: mockToastAdd,
   }),
 }));
 
@@ -374,5 +379,37 @@ describe('FilterSelectors', () => {
 
     expect(wrapper.vm.isOptionDisabled('project', 'proj1')).toBe(true);
     expect(wrapper.vm.isOptionDisabled('project', 'proj2')).toBe(true);
+  });
+
+  describe('toast behaviour', () => {
+    beforeEach(() => {
+      mockToastAdd.mockClear();
+    });
+
+    // Test that toast.add is called when toast prop is true and a filter is updated
+    it('calls toast.add when toast=true and a filter is updated', () => {
+      const wrapper = createWrapper({ toast: true });
+
+      const multiSelect = wrapper.findComponent(MultiSelect);
+      multiSelect.vm.$emit('update:model-value', ['proj1']);
+
+      expect(mockToastAdd).toHaveBeenCalledOnce();
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'info',
+          summary: 'Filters Updated',
+        }),
+      );
+    });
+
+    // Test that toast.add is NOT called when toast prop is false and a filter is updated
+    it('does not call toast.add when toast=false and a filter is updated', () => {
+      const wrapper = createWrapper({ toast: false });
+
+      const multiSelect = wrapper.findComponent(MultiSelect);
+      multiSelect.vm.$emit('update:model-value', ['proj1']);
+
+      expect(mockToastAdd).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/eager/EagerDatastoreDetail.vue
+++ b/src/components/eager/EagerDatastoreDetail.vue
@@ -85,6 +85,7 @@
           :filter-options="filterOptions"
           :dynamic-filter-options="dynamicFilterOptions"
           @clear="clearFilters"
+          :toast="true"
         />
 
         <DatastoreTable

--- a/src/components/lazy/LazyDatastoreDetail.vue
+++ b/src/components/lazy/LazyDatastoreDetail.vue
@@ -86,6 +86,7 @@
           @clear="clearFilters"
           @dropdown-opened="handleDropdownOpened"
           @dropdown-closed="handleDropdownClosed"
+          :toast="true"
         />
 
         <LazyDatastoreTable


### PR DESCRIPTION
Forgot to make the toast configurable in FilterSelectors - it was saying 'Updated Quickstart code' erroneously. This is now fixed. See #195  