### PR TITLE
Max the number of filters per row out at 4

### DIFF
--- a/src/components/FilterSelectors.vue
+++ b/src/components/FilterSelectors.vue
@@ -2,7 +2,7 @@
   <Toast position="top-right" />
   <section class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
     <h6 class="font-semibold mb-4">Filters</h6>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
       <div v-for="(options, column) in filterOptions" :key="column">
         <label class="block text-sm font-medium mb-1">{{ formatColumnName(column) }}</label>
         <MultiSelect


### PR DESCRIPTION
Makes way more sense than 3 now it also works on the metacatalog.