### PR TITLE
Add '& privacy' to about button

### DIFF
--- a/src/components/MetacatHeader.vue
+++ b/src/components/MetacatHeader.vue
@@ -11,7 +11,7 @@
           <div v-if="commitSha && commitSha !== 'unknown'" class="inline-flex">
             <Button
               icon="pi pi-info-circle"
-              label="About"
+              label="About & Privacy"
               aria-label="Reopen welcome guide"
               title="Reopen welcome guide"
               class="p-button-sm bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-md text-sm font-medium transition-colors mx-2"


### PR DESCRIPTION
Following @aidanheerdegen's comments about signposting privacy info a bit better