### PR TITLE
223 bring your own ds

### DIFF
--- a/src/components/MetacatHeader.vue
+++ b/src/components/MetacatHeader.vue
@@ -52,6 +52,13 @@
     <div class="flex-shrink-0">
       <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-right">Documentation</div>
       <div class="flex flex-col space-y-2 items-end">
+        <RouterLink
+          :to="{ name: 'PersonalDatastore' }"
+          class="flex items-center gap-2 text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 transition-colors text-sm font-medium"
+        >
+          <i class="pi pi-upload text-xs"></i>
+          Explore my personal datastore
+        </RouterLink>
         <a
           href="https://intake-esm.readthedocs.io/"
           target="_blank"
@@ -80,6 +87,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { RouterLink } from 'vue-router';
 import Button from 'primevue/button';
 import Popover from 'primevue/popover';
 import GithubFeedbackButton from './GithubFeedbackButton.vue';

--- a/src/components/MetacatHeader.vue
+++ b/src/components/MetacatHeader.vue
@@ -8,6 +8,14 @@
       <div class="flex items-center gap-5">
         <p class="text-gray-600 dark:text-gray-300">Explore the ACCESS-NRI Interactive Catalogue</p>
         <div class="inline-flex items-center">
+          <RouterLink :to="{ name: 'PersonalDatastore' }" class="inline-flex">
+            <Button
+              icon="pi pi-upload"
+              label="Explore my personal datastore"
+              aria-label="Explore my personal datastore"
+              class="p-button-sm bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-md text-sm font-medium transition-colors mx-2"
+            />
+          </RouterLink>
           <div v-if="commitSha && commitSha !== 'unknown'" class="inline-flex">
             <Button
               icon="pi pi-info-circle"
@@ -52,13 +60,6 @@
     <div class="flex-shrink-0">
       <div class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-right">Documentation</div>
       <div class="flex flex-col space-y-2 items-end">
-        <RouterLink
-          :to="{ name: 'PersonalDatastore' }"
-          class="flex items-center gap-2 text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 transition-colors text-sm font-medium"
-        >
-          <i class="pi pi-upload text-xs"></i>
-          Explore my personal datastore
-        </RouterLink>
         <a
           href="https://intake-esm.readthedocs.io/"
           target="_blank"

--- a/src/components/PersonalDatastore.vue
+++ b/src/components/PersonalDatastore.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="personal-datastore-container">
+    <!-- Upload Section -->
+    <div v-if="!isDetailVisible">
+      <div class="mb-6">
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-2">Personal Datastore</h1>
+        <p class="text-gray-600 dark:text-gray-300">
+          Upload your own intake-esm CSV file to browse it using the same interface as the ACCESS-NRI catalogue.
+          Your data stays in your browser session and is never uploaded to any server.
+        </p>
+      </div>
+
+      <!-- Session banner for already-loaded datastore -->
+      <div
+        v-if="catalogStore.hasPersonalDatastore"
+        class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <p class="text-blue-800 dark:text-blue-200 font-medium">
+              <i class="pi pi-check-circle mr-2"></i>
+              <strong>{{ catalogStore.personalDatastore?.name }}</strong> is loaded
+            </p>
+            <p class="text-blue-700 dark:text-blue-300 text-sm mt-1">
+              From <em>{{ catalogStore.personalDatastore?.csvFileName }}</em> —
+              loaded {{ loadedAtFormatted }}
+            </p>
+          </div>
+          <div class="flex gap-2 flex-wrap">
+            <Button
+              label="Browse it"
+              icon="pi pi-search"
+              size="small"
+              @click="showDetail"
+            />
+            <Button
+              label="Replace"
+              icon="pi pi-upload"
+              size="small"
+              severity="secondary"
+              outlined
+              @click="showReplace = true"
+            />
+            <Button
+              label="Clear"
+              icon="pi pi-trash"
+              size="small"
+              severity="danger"
+              outlined
+              @click="handleClear"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Upload form -->
+      <div
+        v-if="!catalogStore.hasPersonalDatastore || showReplace"
+        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 mb-6"
+      >
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          <i class="pi pi-upload mr-2"></i>
+          {{ catalogStore.hasPersonalDatastore ? 'Replace Datastore' : 'Upload Datastore CSV' }}
+        </h2>
+
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Datastore name
+            </label>
+            <InputText
+              v-model="datastoreNameInput"
+              placeholder="e.g. my-project-catalog"
+              class="w-full"
+            />
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              A short label shown in the breadcrumb and quick-start code.
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Intake-ESM CSV file
+            </label>
+            <input
+              ref="fileInputRef"
+              type="file"
+              accept=".csv"
+              class="block w-full text-sm text-gray-700 dark:text-gray-300
+                     file:mr-4 file:py-2 file:px-4
+                     file:rounded file:border-0
+                     file:text-sm file:font-medium
+                     file:bg-blue-50 file:text-blue-700
+                     hover:file:bg-blue-100 dark:file:bg-blue-900/20 dark:file:text-blue-300"
+              @change="handleFileChange"
+            />
+          </div>
+
+          <div v-if="uploadError" class="text-red-600 dark:text-red-400 text-sm">
+            <i class="pi pi-exclamation-triangle mr-1"></i>
+            {{ uploadError }}
+          </div>
+
+          <div class="flex gap-2">
+            <Button
+              label="Load Datastore"
+              icon="pi pi-check"
+              :disabled="!selectedFile || !datastoreNameInput.trim() || uploading"
+              :loading="uploading"
+              @click="handleUpload"
+            />
+            <Button
+              v-if="showReplace"
+              label="Cancel"
+              severity="secondary"
+              outlined
+              @click="showReplace = false"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Info panel when nothing loaded yet -->
+      <div
+        v-if="!catalogStore.hasPersonalDatastore"
+        class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-6"
+      >
+        <h3 class="text-base font-semibold text-gray-700 dark:text-gray-300 mb-2">What is an intake-esm CSV?</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+          An intake-esm catalog CSV contains one row per dataset asset, with columns such as
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">variable</code>,
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">frequency</code>,
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">realm</code>, and
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">path</code>.
+          You can find the CSV file for any intake-esm catalog in its JSON descriptor under the
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">catalog_file</code> key.
+        </p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          <i class="pi pi-info-circle mr-1"></i>
+          Your data is processed locally in-browser using DuckDB WASM — nothing is sent to any server.
+        </p>
+      </div>
+    </div>
+
+    <!-- Detail Section -->
+    <div v-else>
+      <div class="mb-4">
+        <Button
+          label="Back to upload"
+          icon="pi pi-arrow-left"
+          severity="secondary"
+          outlined
+          size="small"
+          @click="hideDetail"
+        />
+      </div>
+      <EagerDatastoreDetail
+        :datastore-name="catalogStore.personalDatastore?.name ?? 'Personal Datastore'"
+        :cache-key="PERSONAL_DATASTORE_CACHE_KEY"
+        source="personal"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import EagerDatastoreDetail from './eager/EagerDatastoreDetail.vue';
+import { useCatalogStore } from '../stores/catalogStore';
+import { PERSONAL_DATASTORE_CACHE_KEY } from '../stores/catalogStore';
+
+const catalogStore = useCatalogStore();
+
+// Upload form state
+const datastoreNameInput = ref('');
+const selectedFile = ref<File | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const uploading = ref(false);
+const uploadError = ref<string | null>(null);
+const showReplace = ref(false);
+const isDetailVisible = ref(false);
+
+const loadedAtFormatted = computed(() => {
+  const date = catalogStore.personalDatastore?.loadedAt;
+  if (!date) return '';
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+});
+
+const handleFileChange = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  selectedFile.value = target.files?.[0] ?? null;
+  uploadError.value = null;
+};
+
+const handleUpload = async () => {
+  const file = selectedFile.value;
+  const name = datastoreNameInput.value.trim();
+  if (!file || !name) return;
+
+  uploading.value = true;
+  uploadError.value = null;
+
+  try {
+    if (catalogStore.hasPersonalDatastore) {
+      await catalogStore.replacePersonalDatastore(file, name);
+    } else {
+      await catalogStore.loadPersonalDatastoreCsv(file, name);
+    }
+    showReplace.value = false;
+    selectedFile.value = null;
+    if (fileInputRef.value) fileInputRef.value.value = '';
+    isDetailVisible.value = true;
+  } catch (err) {
+    uploadError.value = err instanceof Error ? err.message : 'Failed to load datastore';
+  } finally {
+    uploading.value = false;
+  }
+};
+
+const handleClear = () => {
+  catalogStore.clearPersonalDatastore();
+  datastoreNameInput.value = '';
+  selectedFile.value = null;
+  if (fileInputRef.value) fileInputRef.value.value = '';
+};
+
+const showDetail = () => {
+  isDetailVisible.value = true;
+};
+
+const hideDetail = () => {
+  isDetailVisible.value = false;
+};
+</script>
+
+<style scoped>
+.personal-datastore-container {
+  width: 100%;
+  max-width: calc(100vw - 4rem);
+  margin: 0 auto;
+  padding: 2rem;
+}
+</style>

--- a/src/components/PersonalDatastore.vue
+++ b/src/components/PersonalDatastore.vue
@@ -1,7 +1,22 @@
 <template>
   <div class="personal-datastore-container">
     <!-- Upload Section -->
-    <div v-if="!isDetailVisible">
+    <div v-if="!route.params.name">
+      <nav class="mb-6" aria-label="breadcrumb">
+        <ol class="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
+          <li class="flex items-center">
+            <RouterLink to="/" class="flex items-center hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+              <i class="pi pi-table mr-1"></i>
+              Catalog
+            </RouterLink>
+          </li>
+          <li class="flex items-center">
+            <i class="pi pi-angle-right mx-2 text-gray-400"></i>
+            <i class="pi pi-upload mr-1"></i>
+            <span class="font-medium text-gray-900 dark:text-gray-100">Personal Datastore</span>
+          </li>
+        </ol>
+      </nav>
       <div class="mb-6">
         <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-2">Personal Datastore</h1>
         <p class="text-gray-600 dark:text-gray-300">
@@ -26,7 +41,17 @@
             </p>
           </div>
           <div class="flex gap-2 flex-wrap">
-            <Button label="Browse it" icon="pi pi-search" size="small" @click="showDetail" />
+            <Button
+              label="Browse it"
+              icon="pi pi-search"
+              size="small"
+              @click="
+                router.push({
+                  name: 'PersonalDatastoreDetail',
+                  params: { name: slugify(catalogStore.personalDatastore!.name) },
+                })
+              "
+            />
             <Button
               label="Replace"
               icon="pi pi-upload"
@@ -53,9 +78,10 @@
         <div class="space-y-4">
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Datastore name </label>
-            <InputText v-model="datastoreNameInput" placeholder="e.g. my-project-catalog" class="w-full" />
+            <InputText v-model="datastoreNameInput" placeholder="personal-datastore (default)" class="w-full" />
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              A short label shown in the breadcrumb and quick-start code.
+              A short label shown in the breadcrumb and quick-start code. Defaults to
+              <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">personal-datastore</code> if left blank.
             </p>
           </div>
 
@@ -79,7 +105,7 @@
             <Button
               label="Load Datastore"
               icon="pi pi-check"
-              :disabled="!selectedFile || !datastoreNameInput.trim() || uploading"
+              :disabled="!selectedFile || uploading"
               :loading="uploading"
               @click="handleUpload"
             />
@@ -112,16 +138,6 @@
 
     <!-- Detail Section -->
     <div v-else>
-      <div class="mb-4">
-        <Button
-          label="Back to upload"
-          icon="pi pi-arrow-left"
-          severity="secondary"
-          outlined
-          size="small"
-          @click="hideDetail"
-        />
-      </div>
       <EagerDatastoreDetail
         :datastore-name="catalogStore.personalDatastore?.name ?? 'Personal Datastore'"
         :cache-key="PERSONAL_DATASTORE_CACHE_KEY"
@@ -133,6 +149,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+import { useRoute, useRouter, RouterLink } from 'vue-router';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import EagerDatastoreDetail from './eager/EagerDatastoreDetail.vue';
@@ -140,6 +157,15 @@ import { useCatalogStore } from '../stores/catalogStore';
 import { PERSONAL_DATASTORE_CACHE_KEY } from '../stores/catalogStore';
 
 const catalogStore = useCatalogStore();
+const route = useRoute();
+const router = useRouter();
+
+const slugify = (s: string) =>
+  s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'personal-datastore';
 
 // Upload form state
 const datastoreNameInput = ref('');
@@ -148,7 +174,6 @@ const fileInputRef = ref<HTMLInputElement | null>(null);
 const uploading = ref(false);
 const uploadError = ref<string | null>(null);
 const showReplace = ref(false);
-const isDetailVisible = ref(false);
 
 const loadedAtFormatted = computed(() => {
   const date = catalogStore.personalDatastore?.loadedAt;
@@ -164,8 +189,8 @@ const handleFileChange = (event: Event) => {
 
 const handleUpload = async () => {
   const file = selectedFile.value;
-  const name = datastoreNameInput.value.trim();
-  if (!file || !name) return;
+  const name = datastoreNameInput.value.trim() || 'personal-datastore';
+  if (!file) return;
 
   uploading.value = true;
   uploadError.value = null;
@@ -179,7 +204,7 @@ const handleUpload = async () => {
     showReplace.value = false;
     selectedFile.value = null;
     if (fileInputRef.value) fileInputRef.value.value = '';
-    isDetailVisible.value = true;
+    router.push({ name: 'PersonalDatastoreDetail', params: { name: slugify(name) } });
   } catch (err) {
     uploadError.value = err instanceof Error ? err.message : 'Failed to load datastore';
   } finally {
@@ -192,14 +217,7 @@ const handleClear = () => {
   datastoreNameInput.value = '';
   selectedFile.value = null;
   if (fileInputRef.value) fileInputRef.value.value = '';
-};
-
-const showDetail = () => {
-  isDetailVisible.value = true;
-};
-
-const hideDetail = () => {
-  isDetailVisible.value = false;
+  if (route.params.name) router.push({ name: 'PersonalDatastore' });
 };
 </script>
 

--- a/src/components/PersonalDatastore.vue
+++ b/src/components/PersonalDatastore.vue
@@ -5,8 +5,8 @@
       <div class="mb-6">
         <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-2">Personal Datastore</h1>
         <p class="text-gray-600 dark:text-gray-300">
-          Upload your own intake-esm CSV file to browse it using the same interface as the ACCESS-NRI catalogue.
-          Your data stays in your browser session and is never uploaded to any server.
+          Upload your own intake-esm CSV file to browse it using the same interface as the ACCESS-NRI catalogue. Your
+          data stays in your browser session and is never uploaded to any server.
         </p>
       </div>
 
@@ -22,17 +22,11 @@
               <strong>{{ catalogStore.personalDatastore?.name }}</strong> is loaded
             </p>
             <p class="text-blue-700 dark:text-blue-300 text-sm mt-1">
-              From <em>{{ catalogStore.personalDatastore?.csvFileName }}</em> —
-              loaded {{ loadedAtFormatted }}
+              From <em>{{ catalogStore.personalDatastore?.csvFileName }}</em> — loaded {{ loadedAtFormatted }}
             </p>
           </div>
           <div class="flex gap-2 flex-wrap">
-            <Button
-              label="Browse it"
-              icon="pi pi-search"
-              size="small"
-              @click="showDetail"
-            />
+            <Button label="Browse it" icon="pi pi-search" size="small" @click="showDetail" />
             <Button
               label="Replace"
               icon="pi pi-upload"
@@ -41,14 +35,7 @@
               outlined
               @click="showReplace = true"
             />
-            <Button
-              label="Clear"
-              icon="pi pi-trash"
-              size="small"
-              severity="danger"
-              outlined
-              @click="handleClear"
-            />
+            <Button label="Clear" icon="pi pi-trash" size="small" severity="danger" outlined @click="handleClear" />
           </div>
         </div>
       </div>
@@ -65,33 +52,20 @@
 
         <div class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Datastore name
-            </label>
-            <InputText
-              v-model="datastoreNameInput"
-              placeholder="e.g. my-project-catalog"
-              class="w-full"
-            />
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Datastore name </label>
+            <InputText v-model="datastoreNameInput" placeholder="e.g. my-project-catalog" class="w-full" />
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
               A short label shown in the breadcrumb and quick-start code.
             </p>
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Intake-ESM CSV file
-            </label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Intake-ESM CSV file </label>
             <input
               ref="fileInputRef"
               type="file"
               accept=".csv"
-              class="block w-full text-sm text-gray-700 dark:text-gray-300
-                     file:mr-4 file:py-2 file:px-4
-                     file:rounded file:border-0
-                     file:text-sm file:font-medium
-                     file:bg-blue-50 file:text-blue-700
-                     hover:file:bg-blue-100 dark:file:bg-blue-900/20 dark:file:text-blue-300"
+              class="block w-full text-sm text-gray-700 dark:text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 dark:file:bg-blue-900/20 dark:file:text-blue-300"
               @change="handleFileChange"
             />
           </div>
@@ -109,13 +83,7 @@
               :loading="uploading"
               @click="handleUpload"
             />
-            <Button
-              v-if="showReplace"
-              label="Cancel"
-              severity="secondary"
-              outlined
-              @click="showReplace = false"
-            />
+            <Button v-if="showReplace" label="Cancel" severity="secondary" outlined @click="showReplace = false" />
           </div>
         </div>
       </div>
@@ -131,8 +99,8 @@
           <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">variable</code>,
           <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">frequency</code>,
           <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">realm</code>, and
-          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">path</code>.
-          You can find the CSV file for any intake-esm catalog in its JSON descriptor under the
+          <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">path</code>. You can find the CSV file for any
+          intake-esm catalog in its JSON descriptor under the
           <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">catalog_file</code> key.
         </p>
         <p class="text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/__tests__/EagerDatastoreDetail.spec.ts
+++ b/src/components/__tests__/EagerDatastoreDetail.spec.ts
@@ -503,4 +503,34 @@ describe('DatastoreDetail', () => {
 
     expect(loadSpy).toHaveBeenCalledWith('test-datastore');
   });
+
+  it('shows a session-expiry error and "Upload a CSV" button when source is personal and cache is empty', async () => {
+    await router.isReady();
+
+    // No cache entry — simulates a page reload that lost the session data
+    vi.spyOn(catalogStore, 'getDatastoreFromCache').mockReturnValue(null);
+
+    const personalStubs = {
+      Button: true,
+      DatastoreHeader: true,
+      EagerQuickStartCode: true,
+      EagerDatastoreTable: true,
+      FilterSelectors: true,
+      Toast: true,
+      RouterLink: { template: '<a><slot /></a>' },
+    };
+
+    wrapper = mount(EagerDatastoreDetail, {
+      props: { datastoreName: 'my-ds', cacheKey: '__personal_datastore__', source: 'personal' },
+      global: { plugins: [pinia, router, PrimeVue, ToastService], stubs: personalStubs },
+    });
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(wrapper.text()).toContain('Session data unavailable');
+    expect(wrapper.text()).toContain('re-upload your CSV');
+
+    const uploadBtn = wrapper.find('button');
+    expect(uploadBtn.text()).toContain('Upload a CSV');
+  });
 });

--- a/src/components/__tests__/EagerDatastoreDetail.spec.ts
+++ b/src/components/__tests__/EagerDatastoreDetail.spec.ts
@@ -451,6 +451,32 @@ describe('DatastoreDetail', () => {
     expect(wrapper.vm.selectedColumns[0].field).toBe('variable');
   });
 
+  // Test that the personal datastore breadcrumb is shown when source='personal'
+  it('renders the personal datastore breadcrumb when source is personal', async () => {
+    await router.isReady();
+
+    vi.spyOn(catalogStore, 'getDatastoreFromCache').mockReturnValue(createMockDatastoreCache());
+
+    wrapper = mount(EagerDatastoreDetail, {
+      props: { datastoreName: 'my-personal-ds', source: 'personal' },
+      global: {
+        plugins: [pinia, router, PrimeVue, ToastService],
+        stubs: {
+          Button: true,
+          DatastoreHeader: true,
+          EagerQuickStartCode: true,
+          EagerDatastoreTable: true,
+          FilterSelectors: true,
+          Toast: true,
+          RouterLink: { template: '<a><slot /></a>' },
+        },
+      },
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('Personal Datastore');
+  });
+
   // Test that refresh event from table triggers data reload
   it('reloads datastore when refresh event is emitted from table', async () => {
     await router.isReady();

--- a/src/components/__tests__/MetacatHeader.spec.ts
+++ b/src/components/__tests__/MetacatHeader.spec.ts
@@ -46,6 +46,9 @@ describe('MetacatHeader', () => {
           Button,
           Popover,
         },
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+        },
       },
     });
   };

--- a/src/components/__tests__/PersonalDatastore.spec.ts
+++ b/src/components/__tests__/PersonalDatastore.spec.ts
@@ -119,6 +119,32 @@ describe('PersonalDatastore', () => {
       expect(clearSpy).toHaveBeenCalled();
     });
 
+    it('calls replacePersonalDatastore when a datastore is already loaded', async () => {
+      store.personalDatastore = { name: 'old-ds', csvFileName: 'old.csv', loadedAt: new Date() };
+      const replaceSpy = vi.spyOn(store, 'replacePersonalDatastore').mockResolvedValue(undefined);
+
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      // Open the replace form
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace');
+      await replaceBtn?.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      // Pick a file
+      const fileInput = wrapper.find('input[type="file"]');
+      const file = new File(['variable\ntas'], 'new.csv', { type: 'text/csv' });
+      Object.defineProperty(fileInput.element, 'files', { value: [file], configurable: true });
+      await fileInput.trigger('change');
+
+      // Load
+      const loadBtn = wrapper.findAll('button').find((b) => b.text() === 'Load Datastore');
+      await loadBtn?.trigger('click');
+      await flushPromises();
+
+      expect(replaceSpy).toHaveBeenCalledWith(file, 'personal-datastore');
+    });
+
     it('routes to PersonalDatastoreDetail after successful upload', async () => {
       const loadSpy = vi.spyOn(store, 'loadPersonalDatastoreCsv').mockResolvedValue(undefined);
 

--- a/src/components/__tests__/PersonalDatastore.spec.ts
+++ b/src/components/__tests__/PersonalDatastore.spec.ts
@@ -120,9 +120,7 @@ describe('PersonalDatastore', () => {
     });
 
     it('routes to PersonalDatastoreDetail after successful upload', async () => {
-      const loadSpy = vi
-        .spyOn(store, 'loadPersonalDatastoreCsv')
-        .mockResolvedValue(undefined);
+      const loadSpy = vi.spyOn(store, 'loadPersonalDatastoreCsv').mockResolvedValue(undefined);
 
       wrapper = mountComponent();
 

--- a/src/components/__tests__/PersonalDatastore.spec.ts
+++ b/src/components/__tests__/PersonalDatastore.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import PrimeVue from 'primevue/config';
+import PersonalDatastore from '../PersonalDatastore.vue';
+import { useCatalogStore } from '../../stores/catalogStore';
+
+// Routes that mirror the real router
+const routes = [
+  { path: '/', name: 'Home', component: { template: '<div>Home</div>' } },
+  { path: '/personal-datastore', name: 'PersonalDatastore', component: PersonalDatastore },
+  {
+    path: '/personal-datastore/:name',
+    name: 'PersonalDatastoreDetail',
+    component: PersonalDatastore,
+  },
+];
+
+// Stubs shared across all mounts
+const globalStubs = {
+  EagerDatastoreDetail: { template: '<div data-testid="eager-datastore-detail" />' },
+  Button: {
+    template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+    props: ['label', 'icon', 'size', 'severity', 'outlined', 'disabled', 'loading'],
+    emits: ['click'],
+  },
+  InputText: {
+    template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+  },
+};
+
+describe('PersonalDatastore', () => {
+  let wrapper: VueWrapper<any>;
+  let pinia: ReturnType<typeof createPinia>;
+  let router: ReturnType<typeof createRouter>;
+  let store: ReturnType<typeof useCatalogStore>;
+
+  beforeEach(async () => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    router = createRouter({ history: createMemoryHistory(), routes });
+    await router.push('/personal-datastore');
+    await router.isReady();
+    store = useCatalogStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+    vi.restoreAllMocks();
+  });
+
+  const mountComponent = () =>
+    mount(PersonalDatastore, {
+      global: { plugins: [pinia, router, PrimeVue], stubs: globalStubs },
+    });
+
+  // ── Upload page ─────────────────────────────────────────────────────────────
+
+  describe('upload page (no :name route param)', () => {
+    it('shows a breadcrumb link back to the catalog', () => {
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('Catalog');
+      expect(wrapper.text()).toContain('Personal Datastore');
+    });
+
+    it('shows the upload form when no datastore is loaded', () => {
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('Upload Datastore CSV');
+    });
+
+    it('shows the "What is an intake-esm CSV?" info panel when no datastore is loaded', () => {
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('What is an intake-esm CSV?');
+    });
+
+    it('hides the info panel and shows session banner when a datastore is loaded', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain('my-ds');
+      expect(wrapper.text()).not.toContain('What is an intake-esm CSV?');
+    });
+
+    it('hides the upload form when a datastore is loaded and Replace is not open', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).not.toContain('Upload Datastore CSV');
+    });
+
+    it('shows the Replace form when the Replace button is clicked', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      // Click the Replace button (stub renders text label)
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace');
+      await replaceBtn?.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain('Replace Datastore');
+    });
+
+    it('calls clearPersonalDatastore and stays on the upload page when Clear is clicked', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      const clearSpy = vi.spyOn(store, 'clearPersonalDatastore');
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear');
+      await clearBtn?.trigger('click');
+
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('routes to PersonalDatastoreDetail after successful upload', async () => {
+      const loadSpy = vi
+        .spyOn(store, 'loadPersonalDatastoreCsv')
+        .mockResolvedValue(undefined);
+
+      wrapper = mountComponent();
+
+      // Simulate file selection
+      const fileInput = wrapper.find('input[type="file"]');
+      const file = new File(['variable\ntas'], 'my.csv', { type: 'text/csv' });
+      Object.defineProperty(fileInput.element, 'files', { value: [file], configurable: true });
+      await fileInput.trigger('change');
+
+      // Simulate clicking Load Datastore
+      const loadBtn = wrapper.findAll('button').find((b) => b.text() === 'Load Datastore');
+      await loadBtn?.trigger('click');
+      await flushPromises();
+
+      expect(loadSpy).toHaveBeenCalledWith(file, 'personal-datastore');
+      expect(router.currentRoute.value.name).toBe('PersonalDatastoreDetail');
+      expect(router.currentRoute.value.params.name).toBe('personal-datastore');
+    });
+
+    it('displays an error message when upload fails', async () => {
+      vi.spyOn(store, 'loadPersonalDatastoreCsv').mockRejectedValue(new Error('DuckDB parse error'));
+
+      wrapper = mountComponent();
+
+      const fileInput = wrapper.find('input[type="file"]');
+      const file = new File(['bad'], 'my.csv', { type: 'text/csv' });
+      Object.defineProperty(fileInput.element, 'files', { value: [file], configurable: true });
+      await fileInput.trigger('change');
+
+      const loadBtn = wrapper.findAll('button').find((b) => b.text() === 'Load Datastore');
+      await loadBtn?.trigger('click');
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('DuckDB parse error');
+    });
+  });
+
+  // ── Detail page ─────────────────────────────────────────────────────────────
+
+  describe('detail page (:name route param present)', () => {
+    it('renders EagerDatastoreDetail when navigated to the detail route', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      await router.push('/personal-datastore/my-ds');
+      await router.isReady();
+
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="eager-datastore-detail"]').exists()).toBe(true);
+    });
+
+    it('does not render the upload form on the detail route', async () => {
+      store.personalDatastore = { name: 'my-ds', csvFileName: 'my.csv', loadedAt: new Date() };
+      await router.push('/personal-datastore/my-ds');
+      await router.isReady();
+
+      wrapper = mountComponent();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).not.toContain('Upload Datastore CSV');
+    });
+  });
+});

--- a/src/components/eager/EagerDatastoreDetail.vue
+++ b/src/components/eager/EagerDatastoreDetail.vue
@@ -38,10 +38,21 @@
     >
       <div class="flex items-center">
         <i class="pi pi-exclamation-triangle text-red-500 mr-2"></i>
-        <span class="text-red-700 dark:text-red-300 font-medium">Error loading datastore:</span>
+        <span class="text-red-700 dark:text-red-300 font-medium">{{
+          sessionExpired ? 'Session data unavailable' : 'Error loading datastore:'
+        }}</span>
       </div>
       <p class="text-red-600 dark:text-red-400 mt-1">{{ error }}</p>
       <button
+        v-if="sessionExpired"
+        @click="router.push({ name: 'PersonalDatastore' })"
+        class="mt-3 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+      >
+        <i class="pi pi-upload mr-2"></i>
+        Upload a CSV
+      </button>
+      <button
+        v-else
         @click="loadDatastore"
         class="mt-3 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
       >
@@ -146,6 +157,7 @@ const route = useRoute();
 const router = useRouter();
 const { currentFilters, clearFilters } = useFilterState();
 const numDatasets = ref(0);
+const sessionExpired = ref(false);
 
 const routeName = props.source === 'personal' ? 'PersonalDatastoreDetail' : 'DatastoreDetail';
 
@@ -171,6 +183,14 @@ const {
   cacheKeyOverride: props.cacheKey,
   persistCacheOnUnmount: props.source === 'personal',
   skipRouteWatch: props.source === 'personal',
+  onCacheMissing:
+    props.source === 'personal'
+      ? () => {
+          sessionExpired.value = true;
+          error.value =
+            'Your personal datastore is no longer available — browser sessions are not persisted across page reloads. Please re-upload your CSV to continue.';
+        }
+      : undefined,
 });
 
 const rawData = computed(() => cachedDatastore.value?.data || []);

--- a/src/components/eager/EagerDatastoreDetail.vue
+++ b/src/components/eager/EagerDatastoreDetail.vue
@@ -147,7 +147,7 @@ const router = useRouter();
 const { currentFilters, clearFilters } = useFilterState();
 const numDatasets = ref(0);
 
-const routeName = props.source === 'personal' ? 'PersonalDatastore' : 'DatastoreDetail';
+const routeName = props.source === 'personal' ? 'PersonalDatastoreDetail' : 'DatastoreDetail';
 
 const { initializeFiltersFromUrl, stopFilterWatcher } = useFilterUrlSync(route, router, currentFilters, routeName);
 const {

--- a/src/components/eager/EagerDatastoreDetail.vue
+++ b/src/components/eager/EagerDatastoreDetail.vue
@@ -149,12 +149,7 @@ const numDatasets = ref(0);
 
 const routeName = props.source === 'personal' ? 'PersonalDatastore' : 'DatastoreDetail';
 
-const { initializeFiltersFromUrl, stopFilterWatcher } = useFilterUrlSync(
-  route,
-  router,
-  currentFilters,
-  routeName,
-);
+const { initializeFiltersFromUrl, stopFilterWatcher } = useFilterUrlSync(route, router, currentFilters, routeName);
 const {
   datastoreName,
   loading,

--- a/src/components/eager/EagerDatastoreDetail.vue
+++ b/src/components/eager/EagerDatastoreDetail.vue
@@ -8,6 +8,16 @@
             Catalog
           </RouterLink>
         </li>
+        <li v-if="source === 'personal'" class="flex items-center">
+          <i class="pi pi-angle-right mx-2 text-gray-400"></i>
+          <RouterLink
+            :to="{ name: 'PersonalDatastore' }"
+            class="flex items-center hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+          >
+            <i class="pi pi-upload mr-1"></i>
+            Personal Datastore
+          </RouterLink>
+        </li>
         <li class="flex items-center">
           <i class="pi pi-angle-right mx-2 text-gray-400"></i>
           <i class="pi pi-database mr-1"></i>
@@ -77,6 +87,7 @@
           :raw-data="filteredData"
           :dynamic-filter-options="dynamicFilterOptions"
           :num-datasets="numDatasets"
+          :source="source"
           class="mb-6"
         />
 
@@ -117,16 +128,32 @@ import { useFilterUrlSync } from '../../composables/useFilterUrlSync';
 import { filterRowsBySelectedFilters, useDynamicFilterOptions } from '../../composables/useDynamicFilterOptions';
 import type { DatastoreRow } from '../../types/datastore';
 
+const props = withDefaults(
+  defineProps<{
+    /** Override for the datastore name; when absent falls back to route param. */
+    datastoreName?: string;
+    /** Override for the cache key; when absent falls back to the datastore name. */
+    cacheKey?: string;
+    /** Whether to auto-load on mount (default true). */
+    autoLoad?: boolean;
+    /** Whether this is a user-uploaded personal datastore. */
+    source?: 'builtin' | 'personal';
+  }>(),
+  { autoLoad: true, source: 'builtin' },
+);
+
 const route = useRoute();
 const router = useRouter();
 const { currentFilters, clearFilters } = useFilterState();
 const numDatasets = ref(0);
 
+const routeName = props.source === 'personal' ? 'PersonalDatastore' : 'DatastoreDetail';
+
 const { initializeFiltersFromUrl, stopFilterWatcher } = useFilterUrlSync(
   route,
   router,
   currentFilters,
-  'DatastoreDetail',
+  routeName,
 );
 const {
   datastoreName,
@@ -145,6 +172,10 @@ const {
   isCacheReady: (cache) => cache.data.length > 0,
   initializeFiltersFromUrl,
   stopFilterWatcher,
+  nameOverride: props.datastoreName,
+  cacheKeyOverride: props.cacheKey,
+  persistCacheOnUnmount: props.source === 'personal',
+  skipRouteWatch: props.source === 'personal',
 });
 
 const rawData = computed(() => cachedDatastore.value?.data || []);

--- a/src/components/eager/EagerQuickStartCode.vue
+++ b/src/components/eager/EagerQuickStartCode.vue
@@ -44,6 +44,7 @@
         outlined
         size="small"
         class="text-blue-600 border-blue-600 hover:bg-blue-50 mr-3"
+        v-if="source !== 'personal'"
       />
 
       <Button
@@ -70,6 +71,7 @@
 
 <script setup lang="ts">
 import { computed, toRef } from 'vue';
+
 import Button from 'primevue/button';
 import ToggleSwitch from 'primevue/toggleswitch';
 import Toast from 'primevue/toast';
@@ -85,6 +87,8 @@ const props = defineProps<{
   currentFilters: FilterMap;
   rawData: DatastoreRow[];
   dynamicFilterOptions: FilterOptions;
+  /** Whether this is a user-uploaded personal datastore. */
+  source?: 'builtin' | 'personal';
 }>();
 
 /**
@@ -118,6 +122,7 @@ const {
   toRef(props, 'currentFilters'),
   toRef(props, 'dynamicFilterOptions'),
   numDatasets,
+  computed(() => props.source ?? 'builtin'),
 );
 </script>
 

--- a/src/composables/__tests__/useDatastoreDetail.spec.ts
+++ b/src/composables/__tests__/useDatastoreDetail.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount, VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import { useDatastoreDetail } from '../useDatastoreDetail';
+import { useCatalogStore, PERSONAL_DATASTORE_CACHE_KEY } from '../../stores/catalogStore';
+
+vi.mock('../usePosthog', () => ({ capture: vi.fn() }));
+
+const makeRouter = () =>
+  createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'Home', component: { template: '<div />' } },
+      {
+        path: '/personal-datastore/:name',
+        name: 'PersonalDatastoreDetail',
+        component: { template: '<div />' },
+      },
+    ],
+  });
+
+const makeCache = (overrides = {}) => ({
+  data: [{ variable: ['tas'] }],
+  totalRecords: 1,
+  columns: ['variable'],
+  filterOptions: {},
+  loading: false,
+  error: null,
+  project: null,
+  lastFetched: new Date(),
+  ...overrides,
+});
+
+describe('useDatastoreDetail', () => {
+  let pinia: ReturnType<typeof createPinia>;
+  let router: ReturnType<typeof createRouter>;
+  let store: ReturnType<typeof useCatalogStore>;
+  let wrapper: VueWrapper<any> | null = null;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    router = makeRouter();
+    store = useCatalogStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  const mountWithOptions = async (
+    options: Partial<Parameters<typeof useDatastoreDetail>[0]> & { routePath?: string } = {},
+  ) => {
+    const { routePath = '/personal-datastore/my-ds', ...composableOptions } = options;
+
+    await router.push(routePath);
+    await router.isReady();
+
+    const TestComponent = defineComponent({
+      setup() {
+        const result = useDatastoreDetail({
+          loadingStrategy: 'eager',
+          isCacheReady: (cache) => cache.data.length > 0,
+          initializeFiltersFromUrl: vi.fn(),
+          stopFilterWatcher: vi.fn(),
+          ...composableOptions,
+        });
+        return () => h('div', result.datastoreName.value);
+      },
+    });
+
+    return mount(TestComponent, { global: { plugins: [pinia, router] } });
+  };
+
+  describe('skipRouteWatch option', () => {
+    it('does not throw when skipRouteWatch is true and the component unmounts', async () => {
+      store.datastoreCache[PERSONAL_DATASTORE_CACHE_KEY] = makeCache();
+
+      wrapper = await mountWithOptions({
+        nameOverride: 'my-ds',
+        cacheKeyOverride: PERSONAL_DATASTORE_CACHE_KEY,
+        persistCacheOnUnmount: true,
+        skipRouteWatch: true,
+      });
+
+      // Unmounting calls stopRouteWatcher() — which is the noop () => {}
+      expect(() => wrapper!.unmount()).not.toThrow();
+      wrapper = null;
+    });
+
+    it('does not reload when the route param changes with skipRouteWatch true', async () => {
+      store.datastoreCache[PERSONAL_DATASTORE_CACHE_KEY] = makeCache();
+
+      wrapper = await mountWithOptions({
+        nameOverride: 'my-ds',
+        cacheKeyOverride: PERSONAL_DATASTORE_CACHE_KEY,
+        persistCacheOnUnmount: true,
+        skipRouteWatch: true,
+      });
+
+      const loadSpy = vi.spyOn(store, 'loadDatastore');
+
+      // Navigating to a different name should NOT trigger a reload
+      await router.push('/personal-datastore/other-ds');
+      await wrapper.vm.$nextTick();
+
+      expect(loadSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistCacheOnUnmount option', () => {
+    it('clears the cache on unmount when persistCacheOnUnmount is false', async () => {
+      const cacheName = 'test-datastore';
+      store.datastoreCache[cacheName] = makeCache();
+
+      wrapper = await mountWithOptions({
+        nameOverride: cacheName,
+        persistCacheOnUnmount: false,
+        skipRouteWatch: true,
+        routePath: '/',
+      });
+
+      wrapper.unmount();
+      wrapper = null;
+
+      expect(store.getDatastoreFromCache(cacheName)).toBeNull();
+    });
+
+    it('preserves the cache on unmount when persistCacheOnUnmount is true', async () => {
+      store.datastoreCache[PERSONAL_DATASTORE_CACHE_KEY] = makeCache();
+
+      wrapper = await mountWithOptions({
+        nameOverride: 'my-ds',
+        cacheKeyOverride: PERSONAL_DATASTORE_CACHE_KEY,
+        persistCacheOnUnmount: true,
+        skipRouteWatch: true,
+      });
+
+      wrapper.unmount();
+      wrapper = null;
+
+      expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).not.toBeNull();
+    });
+  });
+
+  describe('onCacheMissing option', () => {
+    it('calls onCacheMissing when cacheKeyOverride is set but no cache entry exists', async () => {
+      const onCacheMissing = vi.fn();
+
+      wrapper = await mountWithOptions({
+        nameOverride: 'my-ds',
+        cacheKeyOverride: PERSONAL_DATASTORE_CACHE_KEY,
+        persistCacheOnUnmount: true,
+        skipRouteWatch: true,
+        onCacheMissing,
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(onCacheMissing).toHaveBeenCalled();
+    });
+
+    it('does not call onCacheMissing when the cache is already populated', async () => {
+      store.datastoreCache[PERSONAL_DATASTORE_CACHE_KEY] = makeCache();
+      const onCacheMissing = vi.fn();
+
+      wrapper = await mountWithOptions({
+        nameOverride: 'my-ds',
+        cacheKeyOverride: PERSONAL_DATASTORE_CACHE_KEY,
+        persistCacheOnUnmount: true,
+        skipRouteWatch: true,
+        onCacheMissing,
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(onCacheMissing).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/composables/__tests__/useQuickStartCode.spec.ts
+++ b/src/composables/__tests__/useQuickStartCode.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type MockInstance } from 'vitest';
 import { defineComponent, h, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
@@ -23,7 +23,7 @@ const makeRouter = () =>
 
 describe('useQuickStartCode', () => {
   let router: ReturnType<typeof makeRouter>;
-  let clipboardSpy: ReturnType<typeof vi.spyOn>;
+  let clipboardSpy: MockInstance<(data: string) => Promise<void>>;
 
   beforeEach(() => {
     const pinia = createPinia();

--- a/src/composables/__tests__/useQuickStartCode.spec.ts
+++ b/src/composables/__tests__/useQuickStartCode.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { defineComponent, h, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import { useQuickStartCode } from '../useQuickStartCode';
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() }),
+}));
+
+vi.mock('../usePosthog', () => ({ capture: vi.fn() }));
+
+const makeRouter = () =>
+  createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'Home', component: { template: '<div />' } },
+      { path: '/datastore/:name', name: 'DatastoreDetail', component: { template: '<div />' } },
+      { path: '/personal-datastore', name: 'PersonalDatastore', component: { template: '<div />' } },
+    ],
+  });
+
+describe('useQuickStartCode', () => {
+  let router: ReturnType<typeof makeRouter>;
+  let clipboardSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    router = makeRouter();
+    clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  const mountWithSource = (source: 'builtin' | 'personal') => {
+    const composableRef: { current: ReturnType<typeof useQuickStartCode> | null } = { current: null };
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableRef.current = useQuickStartCode(
+          ref('test-ds'),
+          ref({ variable: ['tas'] }),
+          ref({ variable: ['tas', 'pr'] }),
+          ref(5),
+          ref(source),
+        );
+        return () => h('div');
+      },
+    });
+
+    const wrapper = mount(TestComponent, {
+      global: { plugins: [createPinia(), router] },
+    });
+
+    return { wrapper, composable: composableRef };
+  };
+
+  describe('copySearchLink', () => {
+    it('resolves to the PersonalDatastore route when source is personal', async () => {
+      await router.push('/personal-datastore');
+      await router.isReady();
+
+      const { composable, wrapper } = mountWithSource('personal');
+      await wrapper.vm.$nextTick();
+
+      await composable.current!.copySearchLink();
+
+      expect(clipboardSpy).toHaveBeenCalledOnce();
+      const writtenUrl: string = clipboardSpy.mock.calls[0]![0] as string;
+      expect(writtenUrl).toContain('/personal-datastore');
+    });
+
+    it('resolves to the DatastoreDetail route when source is builtin', async () => {
+      await router.push('/datastore/test-ds');
+      await router.isReady();
+
+      const { composable, wrapper } = mountWithSource('builtin');
+      await wrapper.vm.$nextTick();
+
+      await composable.current!.copySearchLink();
+
+      expect(clipboardSpy).toHaveBeenCalledOnce();
+      const writtenUrl: string = clipboardSpy.mock.calls[0]![0] as string;
+      expect(writtenUrl).toContain('/datastore/test-ds');
+    });
+  });
+});

--- a/src/composables/useDatastoreDetail.ts
+++ b/src/composables/useDatastoreDetail.ts
@@ -22,6 +22,16 @@ interface UseDatastoreDetailOptions {
   onCacheReady?: (cache: DatastoreCache) => void;
   /** Optional hook for caller-specific unmount cleanup. */
   onUnmount?: () => void;
+  /** When provided, overrides the route-derived datastore name. */
+  nameOverride?: string;
+  /** When provided, overrides the cache key used for cache lookups/stores. */
+  cacheKeyOverride?: string;
+  /** When true, the cache entry is NOT deleted on unmount. */
+  persistCacheOnUnmount?: boolean;
+  /** When true, the route-param watcher is not registered. */
+  skipRouteWatch?: boolean;
+  /** Optional hook called when `loadDatastore` finds no cache entry and no loader is triggered. */
+  onCacheMissing?: () => void;
 }
 
 /**
@@ -84,18 +94,24 @@ export function useDatastoreDetail({
   stopFilterWatcher,
   onCacheReady,
   onUnmount,
+  nameOverride,
+  cacheKeyOverride,
+  persistCacheOnUnmount = false,
+  skipRouteWatch = false,
+  onCacheMissing,
 }: UseDatastoreDetailOptions): UseDatastoreDetailResult {
   const route = useRoute();
   const catalogStore = useCatalogStore();
 
-  const datastoreName = computed(() => route.params.name as string);
+  const datastoreName = computed(() => nameOverride ?? (route.params.name as string));
+  const cacheKey = computed(() => cacheKeyOverride ?? datastoreName.value);
   const loading = ref(false);
   const tableLoading = ref(false);
   const error = ref<string | null>(null);
   const availableColumns = ref<TableColumn[]>([]);
   const selectedColumns = ref<TableColumn[]>([]);
 
-  const cachedDatastore = computed(() => catalogStore.getDatastoreFromCache(datastoreName.value));
+  const cachedDatastore = computed(() => catalogStore.getDatastoreFromCache(cacheKey.value));
   const totalRecords = computed(() => cachedDatastore.value?.totalRecords || 0);
   const columns = computed(() => cachedDatastore.value?.columns || []);
   const filterOptions = computed(() => cachedDatastore.value?.filterOptions || {});
@@ -142,12 +158,18 @@ export function useDatastoreDetail({
    * updates loading/error state around that request.
    */
   const loadDatastore = async () => {
-    const existingCache = catalogStore.getDatastoreFromCache(datastoreName.value);
+    const existingCache = catalogStore.getDatastoreFromCache(cacheKey.value);
     if (existingCache && isCacheReady(existingCache)) {
       hydrateFromCache(existingCache);
       loading.value = false;
       tableLoading.value = false;
       trackViewed(existingCache);
+      return;
+    }
+
+    // For personal/override datastores that haven't been loaded yet, notify the caller
+    if (cacheKeyOverride) {
+      onCacheMissing?.();
       return;
     }
 
@@ -169,7 +191,7 @@ export function useDatastoreDetail({
 
   onMounted(() => {
     initializeFiltersFromUrl();
-    const existingCache = catalogStore.getDatastoreFromCache(datastoreName.value);
+    const existingCache = catalogStore.getDatastoreFromCache(cacheKey.value);
     if (existingCache && isCacheReady(existingCache)) {
       hydrateFromCache(existingCache);
       loading.value = false;
@@ -179,20 +201,24 @@ export function useDatastoreDetail({
     }
   });
 
-  const stopRouteWatcher = watch(
-    () => route.params.name,
-    (newName, oldName) => {
-      if (oldName && newName !== oldName) catalogStore.clearDatastoreCache(oldName as string);
-      if (newName) {
-        initializeFiltersFromUrl();
-        void loadDatastore();
-      }
-    },
-  );
+  const stopRouteWatcher = skipRouteWatch
+    ? () => {}
+    : watch(
+        () => route.params.name,
+        (newName, oldName) => {
+          if (oldName && newName !== oldName) catalogStore.clearDatastoreCache(oldName as string);
+          if (newName) {
+            initializeFiltersFromUrl();
+            void loadDatastore();
+          }
+        },
+      );
 
   onUnmounted(() => {
     onUnmount?.();
-    catalogStore.clearDatastoreCache(datastoreName.value);
+    if (!persistCacheOnUnmount) {
+      catalogStore.clearDatastoreCache(cacheKey.value);
+    }
     stopRouteWatcher();
     stopFilterWatcher();
   });

--- a/src/composables/useQuickStartCode.ts
+++ b/src/composables/useQuickStartCode.ts
@@ -10,6 +10,7 @@ import {
   hasActiveQuickStartFilters,
   shouldShowQuickStartCellMethodsWarning,
 } from '../services/quickStartCode';
+import { PERSONAL_DATASTORE_ITERABLE_COLUMNS } from '../stores/catalogStore';
 
 /**
  * Shared composable for the QuickStartCode components (Eager and Lazy).
@@ -26,12 +27,14 @@ import {
  * @param currentFilters - Ref to the per-column active filter map.
  * @param dynamicFilterOptions - Ref to the per-column available options map.
  * @param numDatasets    - Ref to the number of unique datasets currently matched.
+ * @param source         - Ref indicating whether this is a builtin or personal datastore.
  */
 export function useQuickStartCode(
   datastoreName: Ref<string>,
   currentFilters: Ref<FilterMap>,
   dynamicFilterOptions: Ref<FilterOptions>,
   numDatasets: Ref<number>,
+  source: Ref<'builtin' | 'personal'> = ref('builtin'),
 ) {
   const router = useRouter();
   const toast = useToast();
@@ -133,6 +136,8 @@ export function useQuickStartCode(
       currentFilters: currentFilters.value,
       numDatasets: numDatasets.value,
       isXArrayMode: isXArrayMode.value,
+      source: source.value,
+      iterableColumns: source.value === 'personal' ? PERSONAL_DATASTORE_ITERABLE_COLUMNS : [],
     });
   });
 
@@ -159,6 +164,8 @@ export function useQuickStartCode(
    *
    * If the resulting URL exceeds `MAX_URL_LENGTH` the long-URL confirmation
    * dialog is shown instead of copying immediately.
+   *
+   * For personal datastores the link routes to the PersonalDatastore page.
    */
   const copySearchLink = async (): Promise<void> => {
     const query: Record<string, string> = {};
@@ -169,11 +176,12 @@ export function useQuickStartCode(
       }
     }
 
-    const route = router.resolve({
-      name: 'DatastoreDetail',
-      params: { name: datastoreName.value },
-      query,
-    });
+    const routeTarget =
+      source.value === 'personal'
+        ? { name: 'PersonalDatastore', query }
+        : { name: 'DatastoreDetail', params: { name: datastoreName.value }, query };
+
+    const route = router.resolve(routeTarget);
 
     const fullUrl = new URL(route.href, window.location.href).toString();
 

--- a/src/router/__tests__/index.spec.ts
+++ b/src/router/__tests__/index.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import router, { isNavigating } from '../index';
+
+// posthog-js is globally mocked in src/test/setup.ts
+
+describe('router', () => {
+  beforeEach(async () => {
+    await router.push('/');
+    await router.isReady();
+    vi.clearAllMocks();
+  });
+
+  it('resolves the PersonalDatastore route', () => {
+    const resolved = router.resolve({ name: 'PersonalDatastore' });
+    expect(resolved.path).toBe('/personal-datastore');
+  });
+
+  it('resolves the PersonalDatastoreDetail route with a name param', () => {
+    const resolved = router.resolve({ name: 'PersonalDatastoreDetail', params: { name: 'my-ds' } });
+    expect(resolved.path).toBe('/personal-datastore/my-ds');
+  });
+
+  it('sets isNavigating to true inside beforeEach and document.title from meta', async () => {
+    let navigatingDuringGuard = false;
+
+    const remove = router.beforeEach(() => {
+      navigatingDuringGuard = isNavigating.value;
+    });
+
+    await router.push('/personal-datastore/my-ds');
+
+    remove();
+    expect(navigatingDuringGuard).toBe(true);
+    expect(document.title).toBe('Personal Datastore');
+  });
+
+  it('navigates to PersonalDatastoreDetail and reflects the name param', async () => {
+    await router.push({ name: 'PersonalDatastoreDetail', params: { name: 'test-catalog' } });
+    expect(router.currentRoute.value.name).toBe('PersonalDatastoreDetail');
+    expect(router.currentRoute.value.params.name).toBe('test-catalog');
+  });
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,14 @@ const routes = [
       title: 'ESM Datastore Details',
     },
   },
+  {
+    path: '/personal-datastore',
+    name: 'PersonalDatastore',
+    component: () => import('../components/PersonalDatastore.vue'),
+    meta: {
+      title: 'Personal Datastore',
+    },
+  },
   // Future routes can be added here
 ];
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,6 +28,14 @@ const routes = [
       title: 'Personal Datastore',
     },
   },
+  {
+    path: '/personal-datastore/:name',
+    name: 'PersonalDatastoreDetail',
+    component: () => import('../components/PersonalDatastore.vue'),
+    meta: {
+      title: 'Personal Datastore',
+    },
+  },
   // Future routes can be added here
 ];
 

--- a/src/services/__tests__/parquetTransforms.spec.ts
+++ b/src/services/__tests__/parquetTransforms.spec.ts
@@ -93,6 +93,14 @@ describe('parseStringList', () => {
   it('returns null for an empty string', () => {
     expect(parseStringList('')).toBeNull();
   });
+
+  it('returns null when JSON.parse succeeds but the result is not an array', () => {
+    // Force the try-branch to succeed with a non-array so execution falls
+    // through to the final `return null` (line 200 of parquetTransforms.ts).
+    vi.spyOn(JSON, 'parse').mockReturnValueOnce('not-an-array');
+    expect(parseStringList('[anything]')).toBeNull();
+    vi.restoreAllMocks();
+  });
 });
 
 describe('normalizeDatastoreField', () => {
@@ -137,6 +145,12 @@ describe('normalizeDatastoreField', () => {
   it('forces a Vector single value into an array when forceList is true', () => {
     const vector = { toArray: () => ['atmos'] };
     expect(normalizeDatastoreField(vector, true)).toEqual(['atmos']);
+  });
+
+  it('converts a non-string primitive (number) to a string via the else branch', () => {
+    // Numbers are not DuckDB vectors, not arrays, and not strings — they hit
+    // the `else { values = [value] }` branch (line 226 of parquetTransforms.ts).
+    expect(normalizeDatastoreField(42)).toBe('42');
   });
 });
 

--- a/src/services/__tests__/parquetTransforms.spec.ts
+++ b/src/services/__tests__/parquetTransforms.spec.ts
@@ -78,7 +78,7 @@ describe('parseStringList', () => {
     expect(parseStringList('["a","b"]')).toEqual(['a', 'b']);
   });
 
-  it("parses a Python-style bracket string with single quotes", () => {
+  it('parses a Python-style bracket string with single quotes', () => {
     expect(parseStringList("['tas', 'pr']")).toEqual(['tas', 'pr']);
   });
 

--- a/src/services/__tests__/parquetTransforms.spec.ts
+++ b/src/services/__tests__/parquetTransforms.spec.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildRawDataSample, getFilterOptions, normalizeCatalogRows, setupColumns } from '../parquetTransforms';
+import {
+  buildRawDataSample,
+  deriveFilterOptionsFromRows,
+  getFilterOptions,
+  normalizeCatalogRows,
+  normalizeDatastoreField,
+  normalizeDatastoreRows,
+  parseStringList,
+  setupColumns,
+} from '../parquetTransforms';
 
 describe('parquetTransforms', () => {
   it('normalizes catalog rows into the shared catalog shape', () => {
@@ -61,5 +70,113 @@ describe('parquetTransforms', () => {
       variable: ['pr', 'tas'],
       realm: ['atmos', 'ocean'],
     });
+  });
+});
+
+describe('parseStringList', () => {
+  it('parses a JSON-style bracket array string', () => {
+    expect(parseStringList('["a","b"]')).toEqual(['a', 'b']);
+  });
+
+  it("parses a Python-style bracket string with single quotes", () => {
+    expect(parseStringList("['tas', 'pr']")).toEqual(['tas', 'pr']);
+  });
+
+  it('parses bracket-wrapped comma-separated values without quotes', () => {
+    expect(parseStringList('[a, b, c]')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns null for a plain (non-bracket) string', () => {
+    expect(parseStringList('plain-string')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseStringList('')).toBeNull();
+  });
+});
+
+describe('normalizeDatastoreField', () => {
+  it('returns null for null', () => {
+    expect(normalizeDatastoreField(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(normalizeDatastoreField(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(normalizeDatastoreField('')).toBeNull();
+  });
+
+  it('returns a scalar string for a single-item DuckDB Vector', () => {
+    const vector = { toArray: () => ['tas'] };
+    expect(normalizeDatastoreField(vector)).toBe('tas');
+  });
+
+  it('returns an array for a multi-item DuckDB Vector', () => {
+    const vector = { toArray: () => ['tas', 'pr'] };
+    expect(normalizeDatastoreField(vector)).toEqual(['tas', 'pr']);
+  });
+
+  it('returns a scalar string for a plain string', () => {
+    expect(normalizeDatastoreField('daily')).toBe('daily');
+  });
+
+  it('parses a bracket-wrapped string into an array', () => {
+    expect(normalizeDatastoreField("['tas', 'pr']")).toEqual(['tas', 'pr']);
+  });
+
+  it('returns an array for a JS array input', () => {
+    expect(normalizeDatastoreField(['tas', 'pr'])).toEqual(['tas', 'pr']);
+  });
+
+  it('forces a single value into an array when forceList is true', () => {
+    expect(normalizeDatastoreField('daily', true)).toEqual(['daily']);
+  });
+
+  it('forces a Vector single value into an array when forceList is true', () => {
+    const vector = { toArray: () => ['atmos'] };
+    expect(normalizeDatastoreField(vector, true)).toEqual(['atmos']);
+  });
+});
+
+describe('normalizeDatastoreRows', () => {
+  it('coerces iterable columns to arrays and leaves others as scalars', () => {
+    const rows = [{ variable: 'tas', realm: 'atmos' }];
+    const result = normalizeDatastoreRows(rows, ['variable', 'realm'], ['variable']);
+    expect(result[0]!.variable).toEqual(['tas']);
+    expect(result[0]!.realm).toBe('atmos');
+  });
+
+  it('returns null for missing column values', () => {
+    const rows = [{ variable: null }];
+    const result = normalizeDatastoreRows(rows, ['variable']);
+    expect(result[0]!.variable).toBeNull();
+  });
+});
+
+describe('deriveFilterOptionsFromRows', () => {
+  it('collects unique sorted values per column', () => {
+    const rows = [
+      { variable: 'pr', realm: 'ocean' },
+      { variable: ['tas', 'pr'], realm: 'atmos' },
+    ];
+    const opts = deriveFilterOptionsFromRows(rows as any, ['variable', 'realm']);
+    expect(opts.variable).toEqual(['pr', 'tas']);
+    expect(opts.realm).toEqual(['atmos', 'ocean']);
+  });
+
+  it('skips path and filename columns', () => {
+    const rows = [{ path: '/data/file.nc', filename: 'file.nc', realm: 'atmos' }];
+    const opts = deriveFilterOptionsFromRows(rows as any, ['path', 'filename', 'realm']);
+    expect(opts.path).toBeUndefined();
+    expect(opts.filename).toBeUndefined();
+    expect(opts.realm).toEqual(['atmos']);
+  });
+
+  it('ignores null and empty values', () => {
+    const rows = [{ variable: null }, { variable: '' }, { variable: 'tas' }];
+    const opts = deriveFilterOptionsFromRows(rows as any, ['variable']);
+    expect(opts.variable).toEqual(['tas']);
   });
 });

--- a/src/services/__tests__/personalDatastoreCsv.spec.ts
+++ b/src/services/__tests__/personalDatastoreCsv.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseCsvFile } from '../personalDatastoreCsv';
+import * as duckdbClient from '../duckdbClient';
+
+describe('parseCsvFile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when the file does not have a .csv extension', async () => {
+    const file = new File(['data'], 'data.parquet', { type: 'application/octet-stream' });
+    await expect(parseCsvFile(file)).rejects.toThrow('Personal datastore uploads must be CSV files');
+  });
+
+  it('throws when the file is empty', async () => {
+    const file = new File([], 'data.csv', { type: 'text/csv' });
+    await expect(parseCsvFile(file)).rejects.toThrow('The selected file is empty');
+  });
+
+  it('returns columns (excluding "filename") and rows for a valid CSV', async () => {
+    const csvContent = 'variable,realm,filename\ntas,atmos,file1.nc\npr,atmos,file2.nc';
+    const file = new File([csvContent], 'data.csv', { type: 'text/csv' });
+
+    const mockConn = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          // DESCRIBE response — schema rows
+          toArray: () => [
+            { column_name: 'variable' },
+            { column_name: 'realm' },
+            { column_name: 'filename' },
+          ],
+        })
+        .mockResolvedValueOnce({
+          // SELECT * response — data rows
+          toArray: () => [
+            { variable: 'tas', realm: 'atmos', filename: 'file1.nc' },
+            { variable: 'pr', realm: 'atmos', filename: 'file2.nc' },
+          ],
+        }),
+      close: vi.fn(),
+    };
+    const mockDb = {
+      registerFileBuffer: vi.fn(),
+      terminate: vi.fn(),
+    };
+
+    vi.spyOn(duckdbClient, 'initializeDuckDB').mockResolvedValue({ db: mockDb, conn: mockConn } as any);
+
+    const result = await parseCsvFile(file);
+
+    // 'filename' column should be filtered out
+    expect(result.columns).toEqual(['variable', 'realm']);
+    expect(result.rows).toHaveLength(2);
+    expect(mockDb.registerFileBuffer).toHaveBeenCalledWith('personal-datastore.csv', expect.any(Uint8Array));
+  });
+
+  it('always closes the DuckDB connection and terminates the DB, even when the query throws', async () => {
+    const file = new File(['broken csv content'], 'data.csv', { type: 'text/csv' });
+
+    const mockConn = {
+      query: vi.fn().mockRejectedValue(new Error('DuckDB parse error')),
+      close: vi.fn(),
+    };
+    const mockDb = {
+      registerFileBuffer: vi.fn(),
+      terminate: vi.fn(),
+    };
+
+    vi.spyOn(duckdbClient, 'initializeDuckDB').mockResolvedValue({ db: mockDb, conn: mockConn } as any);
+
+    await expect(parseCsvFile(file)).rejects.toThrow('DuckDB parse error');
+    expect(mockConn.close).toHaveBeenCalled();
+    expect(mockDb.terminate).toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/personalDatastoreCsv.spec.ts
+++ b/src/services/__tests__/personalDatastoreCsv.spec.ts
@@ -26,11 +26,7 @@ describe('parseCsvFile', () => {
         .fn()
         .mockResolvedValueOnce({
           // DESCRIBE response — schema rows
-          toArray: () => [
-            { column_name: 'variable' },
-            { column_name: 'realm' },
-            { column_name: 'filename' },
-          ],
+          toArray: () => [{ column_name: 'variable' }, { column_name: 'realm' }, { column_name: 'filename' }],
         })
         .mockResolvedValueOnce({
           // SELECT * response — data rows

--- a/src/services/__tests__/quickStartCode.spec.ts
+++ b/src/services/__tests__/quickStartCode.spec.ts
@@ -122,4 +122,43 @@ describe('quickStartCode', () => {
       }),
     ).toBe(false);
   });
+
+  it('uses intake.open_esm_datastore opening for personal source', () => {
+    const code = buildQuickStartCode({
+      datastoreName: 'my-datastore',
+      currentFilters: {},
+      numDatasets: 0,
+      isXArrayMode: false,
+      source: 'personal',
+    });
+
+    expect(code).toContain('intake.open_esm_datastore("path/to/your/datastore.json")');
+    expect(code).not.toContain('intake.cat.access_nri');
+  });
+
+  it('includes iterableColumns in the personal datastore opening', () => {
+    const code = buildQuickStartCode({
+      datastoreName: 'my-datastore',
+      currentFilters: {},
+      numDatasets: 0,
+      isXArrayMode: false,
+      source: 'personal',
+      iterableColumns: ['variable', 'realm'],
+    });
+
+    expect(code).toContain("columns_with_iterables=['variable', 'realm']");
+  });
+
+  it('omits columns_with_iterables when iterableColumns is empty for personal source', () => {
+    const code = buildQuickStartCode({
+      datastoreName: 'my-datastore',
+      currentFilters: {},
+      numDatasets: 0,
+      isXArrayMode: false,
+      source: 'personal',
+      iterableColumns: [],
+    });
+
+    expect(code).not.toContain('columns_with_iterables');
+  });
 });

--- a/src/services/parquetTransforms.ts
+++ b/src/services/parquetTransforms.ts
@@ -173,3 +173,111 @@ export async function getFilterOptions(
 export function setupColumns(dataColumns: string[]): string[] {
   return dataColumns.filter((col) => col !== '__index_level_0__');
 }
+
+/**
+ * Parses a bracket-wrapped string list such as `"['a', 'b']"` or `'["a","b"]'`
+ * into an array of strings. Returns null when the value is not a bracket-wrapped list.
+ */
+export function parseStringList(value: string): string[] | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed.map(String);
+  } catch {
+    // Fall back to single/double quoted item matching
+    const quotedMatches = Array.from(trimmed.matchAll(/'([^']*)'|"([^"]*)"/g)).map(
+      (match) => match[1] ?? match[2],
+    );
+    if (quotedMatches.length > 0) return quotedMatches.filter((item): item is string => item !== undefined);
+
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes a single field value from a CSV/parquet row.
+ *
+ * - DuckDB Vector → array of strings
+ * - JS array → array of strings
+ * - bracket-wrapped string → parsed array
+ * - scalar string → single string or null when empty
+ *
+ * When `forceList` is true the result is always an array.
+ */
+export function normalizeDatastoreField(value: unknown, forceList = false): string | string[] | null {
+  if (value === null || value === undefined) return null;
+
+  let values: unknown[];
+  if (isDuckDbVector(value)) {
+    values = value.toArray();
+  } else if (Array.isArray(value)) {
+    values = value;
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    values = parseStringList(trimmed) ?? [value];
+  } else {
+    values = [value];
+  }
+
+  const normalized = values.filter((v) => v !== null && v !== undefined && String(v).trim()).map(String);
+  if (normalized.length === 0) return null;
+  if (forceList) return normalized;
+  return normalized.length === 1 ? normalized[0]! : normalized;
+}
+
+/**
+ * Normalizes an array of raw rows into typed DatastoreRow objects.
+ *
+ * Columns listed in `iterableColumns` are always returned as string arrays.
+ * All other columns use scalar-or-array output depending on the data.
+ */
+export function normalizeDatastoreRows(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  iterableColumns: string[] = [],
+): DatastoreRow[] {
+  const iterableColumnSet = new Set(iterableColumns);
+  return rows.map((row) => {
+    const transformedRow: DatastoreRow = {};
+    for (const column of columns) {
+      transformedRow[column] = normalizeDatastoreField(row[column], iterableColumnSet.has(column));
+    }
+    return transformedRow;
+  });
+}
+
+/**
+ * Derives per-column filter options by collecting the unique non-empty values
+ * across all rows. Skips `path` and `filename` columns.
+ */
+export function deriveFilterOptionsFromRows(rows: DatastoreRow[], columns: string[]): FilterOptions {
+  const filterOptions: FilterOptions = {};
+
+  for (const column of columns) {
+    if (column === 'path' || column === 'filename') continue;
+
+    const seen = new Set<string>();
+    for (const row of rows) {
+      const value = row[column];
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          if (item !== null && item !== undefined && String(item).trim()) seen.add(String(item));
+        });
+      } else if (value !== null && value !== undefined && String(value).trim()) {
+        seen.add(String(value));
+      }
+    }
+    filterOptions[column] = Array.from(seen).sort();
+  }
+
+  return filterOptions;
+}

--- a/src/services/parquetTransforms.ts
+++ b/src/services/parquetTransforms.ts
@@ -187,9 +187,7 @@ export function parseStringList(value: string): string[] | null {
     if (Array.isArray(parsed)) return parsed.map(String);
   } catch {
     // Fall back to single/double quoted item matching
-    const quotedMatches = Array.from(trimmed.matchAll(/'([^']*)'|"([^"]*)"/g)).map(
-      (match) => match[1] ?? match[2],
-    );
+    const quotedMatches = Array.from(trimmed.matchAll(/'([^']*)'|"([^"]*)"/g)).map((match) => match[1] ?? match[2]);
     if (quotedMatches.length > 0) return quotedMatches.filter((item): item is string => item !== undefined);
 
     return trimmed

--- a/src/services/personalDatastoreCsv.ts
+++ b/src/services/personalDatastoreCsv.ts
@@ -1,0 +1,41 @@
+import { initializeDuckDB } from './duckdbClient';
+
+/**
+ * Parses an intake-esm CSV file using DuckDB WASM's `read_csv_auto`.
+ *
+ * Returns the raw rows and the list of column names found in the file.
+ * The caller is responsible for normalizing the rows into typed DatastoreRow
+ * objects (see `normalizeDatastoreRows` in parquetTransforms).
+ *
+ * @throws {Error} When the file is not a CSV, is empty, or DuckDB cannot parse it.
+ */
+export async function parseCsvFile(file: File): Promise<{ rows: Record<string, unknown>[]; columns: string[] }> {
+  if (!file.name.toLowerCase().endsWith('.csv')) {
+    throw new Error('Personal datastore uploads must be CSV files');
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  if (arrayBuffer.byteLength === 0) {
+    throw new Error('The selected file is empty');
+  }
+
+  const { db, conn } = await initializeDuckDB();
+
+  try {
+    const fileName = 'personal-datastore.csv';
+    await db.registerFileBuffer(fileName, new Uint8Array(arrayBuffer));
+
+    const schemaResult = await conn.query(`DESCRIBE SELECT * FROM read_csv_auto('${fileName}') LIMIT 1`);
+    const columns = (schemaResult.toArray() as Array<{ column_name: string }>)
+      .map((row) => row.column_name)
+      .filter((col) => col !== 'filename');
+
+    const queryResult = await conn.query(`SELECT * FROM read_csv_auto('${fileName}')`);
+    const rows = queryResult.toArray() as Record<string, unknown>[];
+
+    return { rows, columns };
+  } finally {
+    await conn.close();
+    await db.terminate();
+  }
+}

--- a/src/services/quickStartCode.ts
+++ b/src/services/quickStartCode.ts
@@ -83,9 +83,7 @@ export function buildQuickStartCode({
   const opening =
     source === 'personal'
       ? `# Open your local ESM datastore, for example:\ndatastore = intake.open_esm_datastore("path/to/your/datastore.json"${
-          iterableColumns.length
-            ? `, columns_with_iterables=[${iterableColumns.map((c) => `'${c}'`).join(', ')}]`
-            : ''
+          iterableColumns.length ? `, columns_with_iterables=[${iterableColumns.map((c) => `'${c}'`).join(', ')}]` : ''
         })`
       : `datastore = intake.cat.access_nri["${datastoreName}"]`;
 

--- a/src/services/quickStartCode.ts
+++ b/src/services/quickStartCode.ts
@@ -10,6 +10,10 @@ export interface QuickStartCodeOptions {
   currentFilters: FilterMap;
   numDatasets: number;
   isXArrayMode: boolean;
+  /** Whether this is a personal (user-uploaded) datastore. Default: 'builtin'. */
+  source?: 'builtin' | 'personal';
+  /** Column names that hold iterable values, used in the personal datastore opening. */
+  iterableColumns?: string[];
 }
 
 /**
@@ -73,7 +77,18 @@ export function buildQuickStartCode({
   currentFilters,
   numDatasets,
   isXArrayMode,
+  source = 'builtin',
+  iterableColumns = [],
 }: QuickStartCodeOptions): string {
+  const opening =
+    source === 'personal'
+      ? `# Open your local ESM datastore, for example:\ndatastore = intake.open_esm_datastore("path/to/your/datastore.json"${
+          iterableColumns.length
+            ? `, columns_with_iterables=[${iterableColumns.map((c) => `'${c}'`).join(', ')}]`
+            : ''
+        })`
+      : `datastore = intake.cat.access_nri["${datastoreName}"]`;
+
   let code = `"""
 You will need to run this in an ARE session on Gadi: https://are.nci.org.au/pun/sys/dashboard
 
@@ -85,7 +100,7 @@ from dask.distributed import Client
 
 client = Client(threads_per_worker=1)
 
-datastore = intake.cat.access_nri["${datastoreName}"]`;
+${opening}`;
 
   if (hasActiveQuickStartFilters(currentFilters)) {
     const entries = Object.entries(currentFilters);

--- a/src/stores/__tests__/catalogStore.spec.ts
+++ b/src/stores/__tests__/catalogStore.spec.ts
@@ -4,6 +4,7 @@ import { useCatalogStore, PERSONAL_DATASTORE_CACHE_KEY, PERSONAL_DATASTORE_ITERA
 import * as catalogApi from '../../services/catalogApi';
 import * as duckdbClient from '../../services/duckdbClient';
 import * as parquetTransforms from '../../services/parquetTransforms';
+import * as personalDatastoreCsvModule from '../../services/personalDatastoreCsv';
 import type { CatalogRow } from '../../types/catalog';
 import type { DatastoreCache } from '../../types/datastore';
 
@@ -739,6 +740,40 @@ describe('catalogStore', () => {
       expect(store.hasPersonalDatastore).toBe(false);
       expect(store.personalDatastore).toBeNull();
       expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).toBeNull();
+    });
+
+    it('loadPersonalDatastoreCsv parses the file and registers it', async () => {
+      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockResolvedValue({
+        rows: mockRows,
+        columns: mockColumns,
+      });
+
+      const file = new File(['variable\ntas'], 'catalog.csv', { type: 'text/csv' });
+      await store.loadPersonalDatastoreCsv(file, 'my-catalog');
+
+      expect(store.hasPersonalDatastore).toBe(true);
+      expect(store.personalDatastore?.name).toBe('my-catalog');
+      expect(store.personalDatastore?.csvFileName).toBe('catalog.csv');
+      const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
+      expect(cache?.totalRecords).toBe(2);
+    });
+
+    it('replacePersonalDatastore clears the old entry and loads the new file', async () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, { name: 'old', csvFileName: 'old.csv' });
+
+      const newRows = [{ variable: "['ua']", realm: 'atmos', frequency: 'day', path: '/data/new.nc' }];
+      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockResolvedValue({
+        rows: newRows,
+        columns: mockColumns,
+      });
+
+      const file = new File(['variable\nua'], 'new.csv', { type: 'text/csv' });
+      await store.replacePersonalDatastore(file, 'new-catalog');
+
+      expect(store.personalDatastore?.name).toBe('new-catalog');
+      expect(store.personalDatastore?.csvFileName).toBe('new.csv');
+      const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
+      expect(cache?.totalRecords).toBe(1);
     });
   });
 });

--- a/src/stores/__tests__/catalogStore.spec.ts
+++ b/src/stores/__tests__/catalogStore.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
-import { useCatalogStore } from '../catalogStore';
+import { useCatalogStore, PERSONAL_DATASTORE_CACHE_KEY, PERSONAL_DATASTORE_ITERABLE_COLUMNS } from '../catalogStore';
 import * as catalogApi from '../../services/catalogApi';
 import * as duckdbClient from '../../services/duckdbClient';
 import * as parquetTransforms from '../../services/parquetTransforms';
@@ -649,6 +649,96 @@ describe('catalogStore', () => {
       };
 
       expect(cache.error).toBe('Failed to load');
+    });
+  });
+
+  describe('Personal Datastore', () => {
+    const mockRows = [
+      { variable: "['tas', 'pr']", realm: 'atmos', frequency: 'mon', path: '/data/file1.nc' },
+      { variable: "['ua']", realm: 'atmos', frequency: 'day', path: '/data/file2.nc' },
+    ];
+    const mockColumns = ['variable', 'realm', 'frequency', 'path'];
+
+    it('exports PERSONAL_DATASTORE_CACHE_KEY', () => {
+      expect(PERSONAL_DATASTORE_CACHE_KEY).toBe('__personal_datastore__');
+    });
+
+    it('exports PERSONAL_DATASTORE_ITERABLE_COLUMNS', () => {
+      expect(PERSONAL_DATASTORE_ITERABLE_COLUMNS).toContain('variable');
+    });
+
+    it('initializes with no personal datastore', () => {
+      expect(store.personalDatastore).toBeNull();
+      expect(store.hasPersonalDatastore).toBe(false);
+    });
+
+    it('registerPersonalDatastoreRows sets personal datastore state', () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, {
+        name: 'my-catalog',
+        csvFileName: 'catalog.csv',
+      });
+
+      expect(store.hasPersonalDatastore).toBe(true);
+      expect(store.personalDatastore?.name).toBe('my-catalog');
+      expect(store.personalDatastore?.csvFileName).toBe('catalog.csv');
+      expect(store.personalDatastore?.loadedAt).toBeInstanceOf(Date);
+    });
+
+    it('registerPersonalDatastoreRows populates the cache under PERSONAL_DATASTORE_CACHE_KEY', () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, {
+        name: 'my-catalog',
+        csvFileName: 'catalog.csv',
+      });
+
+      const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
+      expect(cache).not.toBeNull();
+      expect(cache!.totalRecords).toBe(2);
+      expect(cache!.loading).toBe(false);
+    });
+
+    it('registerPersonalDatastoreRows coerces iterable columns to arrays', () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, {
+        name: 'my-catalog',
+        csvFileName: 'catalog.csv',
+      });
+
+      const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
+      const firstRow = cache!.data[0];
+      // variable is an iterable column — must always be an array
+      expect(Array.isArray(firstRow!['variable'])).toBe(true);
+    });
+
+    it('registerPersonalDatastoreRows derives filter options from rows', () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, {
+        name: 'my-catalog',
+        csvFileName: 'catalog.csv',
+      });
+
+      const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
+      expect(cache!.filterOptions['realm']).toContain('atmos');
+      expect(cache!.filterOptions['frequency']).toContain('mon');
+    });
+
+    it('registerPersonalDatastoreRows throws on empty rows', () => {
+      expect(() =>
+        store.registerPersonalDatastoreRows([], mockColumns, {
+          name: 'empty',
+          csvFileName: 'empty.csv',
+        }),
+      ).toThrow();
+    });
+
+    it('clearPersonalDatastore removes state and cache entry', () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, {
+        name: 'my-catalog',
+        csvFileName: 'catalog.csv',
+      });
+
+      store.clearPersonalDatastore();
+
+      expect(store.hasPersonalDatastore).toBe(false);
+      expect(store.personalDatastore).toBeNull();
+      expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).toBeNull();
     });
   });
 });

--- a/src/stores/__tests__/catalogStore.spec.ts
+++ b/src/stores/__tests__/catalogStore.spec.ts
@@ -775,5 +775,20 @@ describe('catalogStore', () => {
       const cache = store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY);
       expect(cache?.totalRecords).toBe(1);
     });
+
+    it('replacePersonalDatastore preserves the existing datastore when parsing the new file throws', async () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, { name: 'old', csvFileName: 'old.csv' });
+
+      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockRejectedValue(
+        new Error('Not a valid CSV'),
+      );
+
+      const file = new File(['bad content'], 'bad.csv', { type: 'text/csv' });
+      await expect(store.replacePersonalDatastore(file, 'new-catalog')).rejects.toThrow('Not a valid CSV');
+
+      // Old datastore must still be intact
+      expect(store.personalDatastore?.name).toBe('old');
+      expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).not.toBeNull();
+    });
   });
 });

--- a/src/stores/__tests__/catalogStore.spec.ts
+++ b/src/stores/__tests__/catalogStore.spec.ts
@@ -779,9 +779,7 @@ describe('catalogStore', () => {
     it('replacePersonalDatastore preserves the existing datastore when parsing the new file throws', async () => {
       store.registerPersonalDatastoreRows(mockRows, mockColumns, { name: 'old', csvFileName: 'old.csv' });
 
-      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockRejectedValue(
-        new Error('Not a valid CSV'),
-      );
+      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockRejectedValue(new Error('Not a valid CSV'));
 
       const file = new File(['bad content'], 'bad.csv', { type: 'text/csv' });
       await expect(store.replacePersonalDatastore(file, 'new-catalog')).rejects.toThrow('Not a valid CSV');

--- a/src/stores/__tests__/catalogStore.spec.ts
+++ b/src/stores/__tests__/catalogStore.spec.ts
@@ -788,5 +788,24 @@ describe('catalogStore', () => {
       expect(store.personalDatastore?.name).toBe('old');
       expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).not.toBeNull();
     });
+
+    it('replacePersonalDatastore preserves the existing datastore when post-parse validation fails (empty rows)', async () => {
+      store.registerPersonalDatastoreRows(mockRows, mockColumns, { name: 'old', csvFileName: 'old.csv' });
+
+      // Parse succeeds but returns zero data rows (header-only CSV)
+      vi.spyOn(personalDatastoreCsvModule, 'parseCsvFile').mockResolvedValue({
+        rows: [],
+        columns: mockColumns,
+      });
+
+      const file = new File(['variable,realm\n'], 'empty.csv', { type: 'text/csv' });
+      await expect(store.replacePersonalDatastore(file, 'new-catalog')).rejects.toThrow(
+        'Cannot register an empty personal datastore',
+      );
+
+      // Old datastore must still be intact
+      expect(store.personalDatastore?.name).toBe('old');
+      expect(store.getDatastoreFromCache(PERSONAL_DATASTORE_CACHE_KEY)).not.toBeNull();
+    });
   });
 });

--- a/src/stores/catalogStore.ts
+++ b/src/stores/catalogStore.ts
@@ -329,11 +329,15 @@ export const useCatalogStore = defineStore('catalog', () => {
 
   /**
    * Replaces the current personal datastore with a new CSV file.
-   * Removes any existing personal datastore cache entry first.
+   *
+   * Parses and validates the new file first. The existing datastore is only
+   * cleared once the new file has been successfully parsed, so a failed
+   * replacement leaves the in-session datastore intact.
    */
   async function replacePersonalDatastore(file: File, datastoreName: string): Promise<void> {
+    const { rows, columns } = await parseCsvFile(file);
     clearPersonalDatastore();
-    await loadPersonalDatastoreCsv(file, datastoreName);
+    registerPersonalDatastoreRows(rows, columns, { name: datastoreName, csvFileName: file.name });
   }
 
   /** Removes the personal datastore state and cache entry. */

--- a/src/stores/catalogStore.ts
+++ b/src/stores/catalogStore.ts
@@ -286,6 +286,38 @@ export const useCatalogStore = defineStore('catalog', () => {
   }
 
   /**
+   * Builds a new personal datastore cache entry and state object from pre-parsed rows.
+   *
+   * Pure computation — does not touch the store. Throws if the rows are invalid
+   * so callers can validate before mutating any existing state.
+   */
+  function buildPersonalDatastoreCache(
+    rows: Record<string, unknown>[],
+    columns: string[],
+    meta: Omit<PersonalDatastoreState, 'loadedAt'>,
+  ): { cache: DatastoreCache; state: PersonalDatastoreState } {
+    if (rows.length === 0) throw new Error('Cannot register an empty personal datastore');
+
+    const displayColumns = setupColumns(columns);
+    const normalizedRows = normalizeDatastoreRows(rows, displayColumns, PERSONAL_DATASTORE_ITERABLE_COLUMNS);
+    const filterOptions = deriveFilterOptionsFromRows(normalizedRows, displayColumns);
+
+    return {
+      cache: {
+        data: normalizedRows,
+        totalRecords: normalizedRows.length,
+        columns: displayColumns,
+        filterOptions,
+        loading: false,
+        error: null,
+        project: null,
+        lastFetched: new Date(),
+      },
+      state: { ...meta, loadedAt: new Date() },
+    };
+  }
+
+  /**
    * Registers pre-parsed CSV rows as a personal datastore in the cache.
    *
    * Normalises iterable columns to arrays and derives filter options from the
@@ -296,25 +328,10 @@ export const useCatalogStore = defineStore('catalog', () => {
     columns: string[],
     meta: Omit<PersonalDatastoreState, 'loadedAt'>,
   ): void {
-    if (rows.length === 0) throw new Error('Cannot register an empty personal datastore');
-
-    const displayColumns = setupColumns(columns);
-    const normalizedRows = normalizeDatastoreRows(rows, displayColumns, PERSONAL_DATASTORE_ITERABLE_COLUMNS);
-    const filterOptions = deriveFilterOptionsFromRows(normalizedRows, displayColumns);
-
-    datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY] = {
-      data: normalizedRows,
-      totalRecords: normalizedRows.length,
-      columns: displayColumns,
-      filterOptions,
-      loading: false,
-      error: null,
-      project: null,
-      lastFetched: new Date(),
-    };
-
-    personalDatastore.value = { ...meta, loadedAt: new Date() };
-    console.log(`✅ Registered personal datastore '${meta.name}' with ${normalizedRows.length} rows`);
+    const { cache, state } = buildPersonalDatastoreCache(rows, columns, meta);
+    datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY] = cache;
+    personalDatastore.value = state;
+    console.log(`✅ Registered personal datastore '${state.name}' with ${cache.totalRecords} rows`);
   }
 
   /**
@@ -330,14 +347,22 @@ export const useCatalogStore = defineStore('catalog', () => {
   /**
    * Replaces the current personal datastore with a new CSV file.
    *
-   * Parses and validates the new file first. The existing datastore is only
-   * cleared once the new file has been successfully parsed, so a failed
-   * replacement leaves the in-session datastore intact.
+   * Both parsing and all post-parse validation run before the existing
+   * datastore is touched. The swap (clear old + write new) is a synchronous
+   * two-line commit that cannot partially fail, so the old state is preserved
+   * if anything throws — including a header-only CSV or future validation.
    */
   async function replacePersonalDatastore(file: File, datastoreName: string): Promise<void> {
     const { rows, columns } = await parseCsvFile(file);
-    clearPersonalDatastore();
-    registerPersonalDatastoreRows(rows, columns, { name: datastoreName, csvFileName: file.name });
+    const { cache, state } = buildPersonalDatastoreCache(rows, columns, {
+      name: datastoreName,
+      csvFileName: file.name,
+    });
+    // Atomic swap — only reached if both parse and build succeeded
+    delete datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY];
+    datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY] = cache;
+    personalDatastore.value = state;
+    console.log(`✅ Replaced personal datastore with '${state.name}' (${cache.totalRecords} rows)`);
   }
 
   /** Removes the personal datastore state and cache entry. */

--- a/src/stores/catalogStore.ts
+++ b/src/stores/catalogStore.ts
@@ -13,12 +13,34 @@ import {
 } from '../services/catalogApi';
 import { initializeDuckDB } from '../services/duckdbClient';
 import {
+  deriveFilterOptionsFromRows,
   getEsmDatastoreSize,
   getFilterOptions,
   loadEsmDatastore,
+  normalizeDatastoreRows,
   queryMetaCatalogPq,
   setupColumns,
 } from '../services/parquetTransforms';
+import { parseCsvFile } from '../services/personalDatastoreCsv';
+
+/** Cache key under which the personal datastore is stored. */
+export const PERSONAL_DATASTORE_CACHE_KEY = '__personal_datastore__';
+
+/** Iterable columns expected in an intake-esm CSV. */
+export const PERSONAL_DATASTORE_ITERABLE_COLUMNS = [
+  'variable',
+  'variable_long_name',
+  'variable_standard_name',
+  'variable_cell_methods',
+  'variable_units',
+];
+
+/** Metadata about the currently loaded personal datastore. */
+export interface PersonalDatastoreState {
+  name: string;
+  csvFileName: string;
+  loadedAt: Date;
+}
 
 export const useCatalogStore = defineStore('catalog', () => {
   // State
@@ -29,6 +51,10 @@ export const useCatalogStore = defineStore('catalog', () => {
 
   // Datastore cache state
   const datastoreCache = ref<Record<string, DatastoreCache>>({});
+
+  // Personal datastore state
+  const personalDatastore = ref<PersonalDatastoreState | null>(null);
+  const hasPersonalDatastore = computed(() => personalDatastore.value !== null);
 
   // Getters
   const catalogCount = computed(() => data.value.length);
@@ -259,6 +285,64 @@ export const useCatalogStore = defineStore('catalog', () => {
     }
   }
 
+  /**
+   * Registers pre-parsed CSV rows as a personal datastore in the cache.
+   *
+   * Normalises iterable columns to arrays and derives filter options from the
+   * row data rather than querying a sidecar parquet file.
+   */
+  function registerPersonalDatastoreRows(
+    rows: Record<string, unknown>[],
+    columns: string[],
+    meta: Omit<PersonalDatastoreState, 'loadedAt'>,
+  ): void {
+    if (rows.length === 0) throw new Error('Cannot register an empty personal datastore');
+
+    const displayColumns = setupColumns(columns);
+    const normalizedRows = normalizeDatastoreRows(rows, displayColumns, PERSONAL_DATASTORE_ITERABLE_COLUMNS);
+    const filterOptions = deriveFilterOptionsFromRows(normalizedRows, displayColumns);
+
+    datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY] = {
+      data: normalizedRows,
+      totalRecords: normalizedRows.length,
+      columns: displayColumns,
+      filterOptions,
+      loading: false,
+      error: null,
+      project: null,
+      lastFetched: new Date(),
+    };
+
+    personalDatastore.value = { ...meta, loadedAt: new Date() };
+    console.log(`✅ Registered personal datastore '${meta.name}' with ${normalizedRows.length} rows`);
+  }
+
+  /**
+   * Parses a CSV file and registers it as the personal datastore.
+   *
+   * This is the high-level entry point used by the upload UI.
+   */
+  async function loadPersonalDatastoreCsv(file: File, datastoreName: string): Promise<void> {
+    const { rows, columns } = await parseCsvFile(file);
+    registerPersonalDatastoreRows(rows, columns, { name: datastoreName, csvFileName: file.name });
+  }
+
+  /**
+   * Replaces the current personal datastore with a new CSV file.
+   * Removes any existing personal datastore cache entry first.
+   */
+  async function replacePersonalDatastore(file: File, datastoreName: string): Promise<void> {
+    clearPersonalDatastore();
+    await loadPersonalDatastoreCsv(file, datastoreName);
+  }
+
+  /** Removes the personal datastore state and cache entry. */
+  function clearPersonalDatastore(): void {
+    delete datastoreCache.value[PERSONAL_DATASTORE_CACHE_KEY];
+    personalDatastore.value = null;
+    console.log('🗑️ Cleared personal datastore');
+  }
+
   return {
     // State
     data,
@@ -266,6 +350,8 @@ export const useCatalogStore = defineStore('catalog', () => {
     error,
     rawDataSample,
     datastoreCache,
+    personalDatastore,
+    hasPersonalDatastore,
 
     // Getters
     catalogCount,
@@ -282,6 +368,12 @@ export const useCatalogStore = defineStore('catalog', () => {
     getDatastoreFromCache,
     isDatastoreLoading,
     clearDatastoreCache,
+
+    // Personal datastore
+    registerPersonalDatastoreRows,
+    loadPersonalDatastoreCsv,
+    replacePersonalDatastore,
+    clearPersonalDatastore,
 
     // Utility functions for other components
     fetchMetaCatFile,


### PR DESCRIPTION
Closes #223 

impl: Claude sonnet, 4.6

Allow users to upload their own intake-esm CSV file and browse it in
the same table/filter UI as built-in ACCESS-NRI datastores. Data is
processed entirely in-browser via DuckDB WASM — nothing is sent to any
server. The session is ephemeral: refreshing the page clears the data.

New files
---------
- src/services/personalDatastoreCsv.ts
  parseCsvFile() — validates the .csv extension, registers the buffer
  with DuckDB, queries schema and rows via read_csv_auto.

- src/components/PersonalDatastore.vue
  Upload form (file picker + name input) with load/replace/clear
  controls. On success, transitions inline to EagerDatastoreDetail
  rendered in personal mode.

Changed files
-------------
- src/services/parquetTransforms.ts
  Added parseStringList, normalizeDatastoreField, normalizeDatastoreRows,
  deriveFilterOptionsFromRows — pure helpers for normalising CSV rows and
  deriving per-column filter option lists without a sidecar parquet file.

- src/services/quickStartCode.ts
  QuickStartCodeOptions gains optional \`source\` ('builtin'|'personal')
  and \`iterableColumns\`. When source is 'personal' the opening line
  switches to intake.open_esm_datastore(..., columns_with_iterables=[...]).

- src/stores/catalogStore.ts
  Exports: PERSONAL_DATASTORE_CACHE_KEY, PERSONAL_DATASTORE_ITERABLE_COLUMNS,
  PersonalDatastoreState interface.
  New state: personalDatastore ref, hasPersonalDatastore computed.
  New actions: registerPersonalDatastoreRows, loadPersonalDatastoreCsv,
  replacePersonalDatastore, clearPersonalDatastore.

- src/composables/useDatastoreDetail.ts
  Five new optional options: nameOverride, cacheKeyOverride,
  persistCacheOnUnmount, skipRouteWatch, onCacheMissing — enabling the
  composable to drive a personal (non-route-derived) datastore view.

- src/composables/useQuickStartCode.ts
  Accepts a new optional \`source\` Ref parameter. Passes source and
  iterable columns through to buildQuickStartCode. Routes copySearchLink
  to the PersonalDatastore route when source is 'personal'.

- src/components/eager/EagerDatastoreDetail.vue
  New props: datastoreName?, cacheKey?, autoLoad?, source?.
  Wires overrides into useDatastoreDetail. Adds a personal-datastore
  breadcrumb segment when source === 'personal'.

- src/components/eager/EagerQuickStartCode.vue
  New optional \`source\` prop. Hides 'Copy Link to Search' for personal
  datastores. Passes source to useQuickStartCode.

- src/router/index.ts
  Adds /personal-datastore route (name: 'PersonalDatastore').

- src/components/MetacatHeader.vue
  Adds 'Explore my personal datastore' RouterLink in the docs section.

Tests
-----
- src/stores/__tests__/catalogStore.spec.ts
  New 'Personal Datastore' describe block: exports, initial state,
  registerPersonalDatastoreRows (state, cache population, iterable
  coercion, filter option derivation, empty-rows rejection),
  clearPersonalDatastore.
- src/components/__tests__/MetacatHeader.spec.ts
  Added RouterLink stub to mount options (required after adding RouterLink
  to the MetacatHeader template).